### PR TITLE
Implement cakelamp-core Rust tensor library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+members = ["crates/cakelamp-core"]
+resolver = "2"

--- a/crates/cakelamp-core/Cargo.toml
+++ b/crates/cakelamp-core/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "cakelamp-core"
+version = "0.1.0"
+edition = "2021"
+description = "CakeLamp: A lightweight tensor library with f32-only storage"
+
+[dependencies]
+rand = "0.8"

--- a/crates/cakelamp-core/src/broadcast.rs
+++ b/crates/cakelamp-core/src/broadcast.rs
@@ -1,0 +1,73 @@
+/// Compute the broadcast shape of two shapes, following NumPy/PyTorch rules.
+/// Returns None if the shapes are not broadcastable.
+pub fn broadcast_shape(a: &[usize], b: &[usize]) -> Option<Vec<usize>> {
+    let max_ndim = a.len().max(b.len());
+    let mut result = Vec::with_capacity(max_ndim);
+
+    for i in 0..max_ndim {
+        let da = if i < max_ndim - a.len() { 1 } else { a[i - (max_ndim - a.len())] };
+        let db = if i < max_ndim - b.len() { 1 } else { b[i - (max_ndim - b.len())] };
+
+        if da == db {
+            result.push(da);
+        } else if da == 1 {
+            result.push(db);
+        } else if db == 1 {
+            result.push(da);
+        } else {
+            return None;
+        }
+    }
+
+    Some(result)
+}
+
+/// Compute strides for broadcasting `shape` to `target_shape`.
+/// Dimensions that were size 1 (broadcast) get stride 0.
+pub fn broadcast_strides(shape: &[usize], strides: &[usize], target_shape: &[usize]) -> Vec<usize> {
+    let ndim = target_shape.len();
+    let offset = ndim - shape.len();
+    let mut result = vec![0usize; ndim];
+
+    for i in 0..ndim {
+        if i < offset {
+            result[i] = 0; // prepended dimension
+        } else {
+            let orig_idx = i - offset;
+            if shape[orig_idx] == target_shape[i] {
+                result[i] = strides[orig_idx];
+            } else {
+                // shape[orig_idx] == 1, broadcast
+                result[i] = 0;
+            }
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_broadcast_shape_same() {
+        assert_eq!(broadcast_shape(&[3, 4], &[3, 4]), Some(vec![3, 4]));
+    }
+
+    #[test]
+    fn test_broadcast_shape_scalar() {
+        assert_eq!(broadcast_shape(&[3, 4], &[1]), Some(vec![3, 4]));
+    }
+
+    #[test]
+    fn test_broadcast_shape_diff_ndim() {
+        assert_eq!(broadcast_shape(&[3, 1], &[1, 4]), Some(vec![3, 4]));
+        assert_eq!(broadcast_shape(&[5, 3, 1], &[4]), Some(vec![5, 3, 4]));
+    }
+
+    #[test]
+    fn test_broadcast_shape_incompatible() {
+        assert_eq!(broadcast_shape(&[3, 4], &[3, 5]), None);
+    }
+}

--- a/crates/cakelamp-core/src/lib.rs
+++ b/crates/cakelamp-core/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod storage;
+pub mod tensor;
+pub mod ops;
+pub mod broadcast;
+
+pub use tensor::Tensor;

--- a/crates/cakelamp-core/src/ops.rs
+++ b/crates/cakelamp-core/src/ops.rs
@@ -1,0 +1,686 @@
+//! Tensor operations: element-wise, reductions, matmul, activations.
+
+use crate::broadcast::{broadcast_shape, broadcast_strides};
+use crate::tensor::Tensor;
+
+// ---- Element-wise binary ops with broadcasting ----
+
+fn binary_op_broadcast(a: &Tensor, b: &Tensor, f: impl Fn(f32, f32) -> f32) -> Tensor {
+    let out_shape = broadcast_shape(a.shape(), b.shape())
+        .expect("Shapes are not broadcastable");
+
+    let a_strides = broadcast_strides(a.shape(), a.strides(), &out_shape);
+    let b_strides = broadcast_strides(b.shape(), b.strides(), &out_shape);
+
+    let numel: usize = out_shape.iter().product();
+    let ndim = out_shape.len();
+    let mut result = Vec::with_capacity(numel);
+
+    let a_storage = a.storage.borrow();
+    let b_storage = b.storage.borrow();
+
+    let mut coord = vec![0usize; ndim];
+    for _ in 0..numel {
+        let mut a_idx = a.storage_offset;
+        let mut b_idx = b.storage_offset;
+        for d in 0..ndim {
+            a_idx += coord[d] * a_strides[d];
+            b_idx += coord[d] * b_strides[d];
+        }
+        result.push(f(a_storage.data[a_idx], b_storage.data[b_idx]));
+
+        // Increment coordinate
+        for d in (0..ndim).rev() {
+            coord[d] += 1;
+            if coord[d] < out_shape[d] {
+                break;
+            }
+            coord[d] = 0;
+        }
+    }
+
+    Tensor::from_data(result, out_shape)
+}
+
+fn unary_op(a: &Tensor, f: impl Fn(f32) -> f32) -> Tensor {
+    let data = a.to_vec();
+    let result: Vec<f32> = data.iter().map(|&x| f(x)).collect();
+    Tensor::from_data(result, a.shape().to_vec())
+}
+
+// ---- Element-wise arithmetic ----
+
+/// Element-wise addition with broadcasting.
+pub fn add(a: &Tensor, b: &Tensor) -> Tensor {
+    binary_op_broadcast(a, b, |x, y| x + y)
+}
+
+/// Element-wise subtraction with broadcasting.
+pub fn sub(a: &Tensor, b: &Tensor) -> Tensor {
+    binary_op_broadcast(a, b, |x, y| x - y)
+}
+
+/// Element-wise multiplication with broadcasting.
+pub fn mul(a: &Tensor, b: &Tensor) -> Tensor {
+    binary_op_broadcast(a, b, |x, y| x * y)
+}
+
+/// Element-wise division with broadcasting.
+pub fn div(a: &Tensor, b: &Tensor) -> Tensor {
+    binary_op_broadcast(a, b, |x, y| x / y)
+}
+
+/// Element-wise power with broadcasting.
+pub fn pow(a: &Tensor, b: &Tensor) -> Tensor {
+    binary_op_broadcast(a, b, |x, y| x.powf(y))
+}
+
+// ---- Scalar ops ----
+
+/// Add a scalar to every element.
+pub fn add_scalar(a: &Tensor, s: f32) -> Tensor {
+    unary_op(a, |x| x + s)
+}
+
+/// Multiply every element by a scalar.
+pub fn mul_scalar(a: &Tensor, s: f32) -> Tensor {
+    unary_op(a, |x| x * s)
+}
+
+// ---- Unary ops ----
+
+/// Element-wise negation.
+pub fn neg(a: &Tensor) -> Tensor {
+    unary_op(a, |x| -x)
+}
+
+/// Element-wise exponential.
+pub fn exp(a: &Tensor) -> Tensor {
+    unary_op(a, |x| x.exp())
+}
+
+/// Element-wise natural logarithm.
+pub fn log(a: &Tensor) -> Tensor {
+    unary_op(a, |x| x.ln())
+}
+
+/// Element-wise ReLU: max(0, x).
+pub fn relu(a: &Tensor) -> Tensor {
+    unary_op(a, |x| x.max(0.0))
+}
+
+/// Element-wise sigmoid: 1 / (1 + exp(-x)).
+pub fn sigmoid(a: &Tensor) -> Tensor {
+    unary_op(a, |x| 1.0 / (1.0 + (-x).exp()))
+}
+
+/// Element-wise tanh.
+pub fn tanh(a: &Tensor) -> Tensor {
+    unary_op(a, |x| x.tanh())
+}
+
+/// Element-wise absolute value.
+pub fn abs(a: &Tensor) -> Tensor {
+    unary_op(a, |x| x.abs())
+}
+
+/// Element-wise square root.
+pub fn sqrt(a: &Tensor) -> Tensor {
+    unary_op(a, |x| x.sqrt())
+}
+
+/// Element-wise clamp.
+pub fn clamp(a: &Tensor, min: f32, max: f32) -> Tensor {
+    unary_op(a, |x| x.clamp(min, max))
+}
+
+// ---- Comparison ops ----
+
+/// Element-wise equality (returns 1.0 for true, 0.0 for false).
+pub fn eq(a: &Tensor, b: &Tensor) -> Tensor {
+    binary_op_broadcast(a, b, |x, y| if (x - y).abs() < 1e-7 { 1.0 } else { 0.0 })
+}
+
+/// Element-wise greater than.
+pub fn gt(a: &Tensor, b: &Tensor) -> Tensor {
+    binary_op_broadcast(a, b, |x, y| if x > y { 1.0 } else { 0.0 })
+}
+
+// ---- Reduction ops ----
+
+/// Sum all elements, returning a scalar tensor.
+pub fn sum(a: &Tensor) -> Tensor {
+    let data = a.to_vec();
+    let s: f32 = data.iter().sum();
+    Tensor::scalar(s)
+}
+
+/// Sum along a specific dimension.
+pub fn sum_dim(a: &Tensor, dim: usize, keepdim: bool) -> Tensor {
+    assert!(dim < a.ndim(), "Dimension out of range");
+    let shape = a.shape();
+    let dim_size = shape[dim];
+
+    // Build output shape
+    let mut out_shape: Vec<usize> = shape.to_vec();
+    out_shape[dim] = 1;
+
+    let out_numel: usize = out_shape.iter().product();
+    let mut result = vec![0.0f32; out_numel];
+    let out_strides = Tensor::compute_contiguous_strides(&out_shape);
+
+    let data = a.to_vec();
+    let in_strides = Tensor::compute_contiguous_strides(shape);
+
+    // Iterate over all positions in the output
+    let ndim = shape.len();
+    let mut coord = vec![0usize; ndim];
+    for _ in 0..out_numel {
+        let mut out_idx = 0;
+        for d in 0..ndim {
+            out_idx += coord[d] * out_strides[d];
+        }
+
+        // Sum along the reduction dimension
+        let mut s = 0.0;
+        for k in 0..dim_size {
+            let mut in_idx = 0;
+            for d in 0..ndim {
+                if d == dim {
+                    in_idx += k * in_strides[d];
+                } else {
+                    in_idx += coord[d] * in_strides[d];
+                }
+            }
+            s += data[in_idx];
+        }
+        result[out_idx] = s;
+
+        // Increment coord (skip the reduction dim)
+        for d in (0..ndim).rev() {
+            if d == dim {
+                continue;
+            }
+            coord[d] += 1;
+            if coord[d] < out_shape[d] {
+                break;
+            }
+            coord[d] = 0;
+        }
+    }
+
+    if keepdim {
+        Tensor::from_data(result, out_shape)
+    } else {
+        let mut squeezed_shape: Vec<usize> = Vec::new();
+        for (i, &s) in out_shape.iter().enumerate() {
+            if i != dim {
+                squeezed_shape.push(s);
+            }
+        }
+        if squeezed_shape.is_empty() {
+            Tensor::scalar(result[0])
+        } else {
+            Tensor::from_data(result, squeezed_shape)
+        }
+    }
+}
+
+/// Mean of all elements, returning a scalar tensor.
+pub fn mean(a: &Tensor) -> Tensor {
+    let s = sum(a).item();
+    Tensor::scalar(s / a.numel() as f32)
+}
+
+/// Mean along a specific dimension.
+pub fn mean_dim(a: &Tensor, dim: usize, keepdim: bool) -> Tensor {
+    let dim_size = a.shape()[dim] as f32;
+    let s = sum_dim(a, dim, keepdim);
+    mul_scalar(&s, 1.0 / dim_size)
+}
+
+/// Max of all elements, returning a scalar tensor.
+pub fn max(a: &Tensor) -> Tensor {
+    let data = a.to_vec();
+    let m = data.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+    Tensor::scalar(m)
+}
+
+/// Min of all elements, returning a scalar tensor.
+pub fn min(a: &Tensor) -> Tensor {
+    let data = a.to_vec();
+    let m = data.iter().cloned().fold(f32::INFINITY, f32::min);
+    Tensor::scalar(m)
+}
+
+/// Argmax along a dimension.
+pub fn argmax(a: &Tensor, dim: usize) -> Tensor {
+    assert!(dim < a.ndim(), "Dimension out of range");
+    let shape = a.shape();
+    let dim_size = shape[dim];
+
+    let mut out_shape: Vec<usize> = shape.to_vec();
+    out_shape.remove(dim);
+    if out_shape.is_empty() {
+        // 1D tensor
+        let data = a.to_vec();
+        let (idx, _) = data.iter().enumerate()
+            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
+            .unwrap();
+        return Tensor::scalar(idx as f32);
+    }
+
+    let out_numel: usize = out_shape.iter().product();
+    let mut result = vec![0.0f32; out_numel];
+
+    let data = a.to_vec();
+    let in_strides = Tensor::compute_contiguous_strides(shape);
+
+    let ndim = out_shape.len();
+    let mut coord = vec![0usize; ndim];
+    for out_i in 0..out_numel {
+        let mut best_val = f32::NEG_INFINITY;
+        let mut best_idx = 0usize;
+
+        for k in 0..dim_size {
+            // Reconstruct the full input coordinate
+            let mut in_idx = 0;
+            let mut out_d = 0;
+            for d in 0..shape.len() {
+                if d == dim {
+                    in_idx += k * in_strides[d];
+                } else {
+                    in_idx += coord[out_d] * in_strides[d];
+                    out_d += 1;
+                }
+            }
+            if data[in_idx] > best_val {
+                best_val = data[in_idx];
+                best_idx = k;
+            }
+        }
+        result[out_i] = best_idx as f32;
+
+        // Increment coord
+        for d in (0..ndim).rev() {
+            coord[d] += 1;
+            if coord[d] < out_shape[d] {
+                break;
+            }
+            coord[d] = 0;
+        }
+    }
+
+    Tensor::from_data(result, out_shape)
+}
+
+// ---- Matrix operations ----
+
+/// Matrix multiplication for 2D tensors.
+/// a: (M, K), b: (K, N) -> result: (M, N)
+pub fn matmul(a: &Tensor, b: &Tensor) -> Tensor {
+    assert_eq!(a.ndim(), 2, "matmul requires 2D tensors");
+    assert_eq!(b.ndim(), 2, "matmul requires 2D tensors");
+    let m = a.shape()[0];
+    let k = a.shape()[1];
+    let n = b.shape()[1];
+    assert_eq!(k, b.shape()[0], "Inner dimensions must match for matmul");
+
+    let a_data = a.to_vec();
+    let b_data = b.contiguous().to_vec();
+    let mut result = vec![0.0f32; m * n];
+
+    for i in 0..m {
+        for j in 0..n {
+            let mut s = 0.0f32;
+            for p in 0..k {
+                s += a_data[i * k + p] * b_data[p * n + j];
+            }
+            result[i * n + j] = s;
+        }
+    }
+
+    Tensor::from_data(result, vec![m, n])
+}
+
+/// Batched matrix multiplication.
+/// Handles broadcasting of batch dimensions.
+/// a: (..., M, K), b: (..., K, N) -> (..., M, N)
+pub fn bmm(a: &Tensor, b: &Tensor) -> Tensor {
+    assert!(a.ndim() >= 2 && b.ndim() >= 2, "bmm requires at least 2D tensors");
+
+    if a.ndim() == 2 && b.ndim() == 2 {
+        return matmul(a, b);
+    }
+
+    let a_shape = a.shape();
+    let b_shape = b.shape();
+    let m = a_shape[a_shape.len() - 2];
+    let k = a_shape[a_shape.len() - 1];
+    let n = b_shape[b_shape.len() - 1];
+    assert_eq!(k, b_shape[b_shape.len() - 2], "Inner dimensions must match");
+
+    // For now, handle 3D case: (B, M, K) x (B, K, N)
+    assert_eq!(a.ndim(), 3, "bmm currently supports 3D tensors");
+    assert_eq!(b.ndim(), 3, "bmm currently supports 3D tensors");
+    let batch = a_shape[0];
+    assert_eq!(batch, b_shape[0], "Batch dimensions must match");
+
+    let a_data = a.contiguous().to_vec();
+    let b_data = b.contiguous().to_vec();
+    let mut result = vec![0.0f32; batch * m * n];
+
+    for bi in 0..batch {
+        for i in 0..m {
+            for j in 0..n {
+                let mut s = 0.0f32;
+                for p in 0..k {
+                    s += a_data[bi * m * k + i * k + p] * b_data[bi * k * n + p * n + j];
+                }
+                result[bi * m * n + i * n + j] = s;
+            }
+        }
+    }
+
+    Tensor::from_data(result, vec![batch, m, n])
+}
+
+// ---- Softmax ----
+
+/// Softmax along a dimension.
+pub fn softmax(a: &Tensor, dim: usize) -> Tensor {
+    // Subtract max for numerical stability
+    let shape = a.shape();
+    let data = a.to_vec();
+    let strides = Tensor::compute_contiguous_strides(shape);
+    let ndim = shape.len();
+
+    let mut out_shape = shape.to_vec();
+    out_shape[dim] = 1;
+    let out_numel: usize = out_shape.iter().product();
+    let out_strides = Tensor::compute_contiguous_strides(&out_shape);
+
+    // First pass: find max along dim
+    let mut maxes = vec![f32::NEG_INFINITY; out_numel];
+    let mut coord = vec![0usize; ndim];
+    let total: usize = shape.iter().product();
+    for _ in 0..total {
+        let mut in_idx = 0;
+        let mut out_idx = 0;
+        for d in 0..ndim {
+            in_idx += coord[d] * strides[d];
+            if d != dim {
+                out_idx += coord[d] * out_strides[d];
+            }
+        }
+        if data[in_idx] > maxes[out_idx] {
+            maxes[out_idx] = data[in_idx];
+        }
+        for d in (0..ndim).rev() {
+            coord[d] += 1;
+            if coord[d] < shape[d] { break; }
+            coord[d] = 0;
+        }
+    }
+
+    // Second pass: exp(x - max) and sum
+    let mut exp_sums = vec![0.0f32; out_numel];
+    let mut result = vec![0.0f32; total];
+    coord = vec![0usize; ndim];
+    for flat_i in 0..total {
+        let mut in_idx = 0;
+        let mut out_idx = 0;
+        for d in 0..ndim {
+            in_idx += coord[d] * strides[d];
+            if d != dim {
+                out_idx += coord[d] * out_strides[d];
+            }
+        }
+        let e = (data[in_idx] - maxes[out_idx]).exp();
+        result[flat_i] = e;
+        exp_sums[out_idx] += e;
+        for d in (0..ndim).rev() {
+            coord[d] += 1;
+            if coord[d] < shape[d] { break; }
+            coord[d] = 0;
+        }
+    }
+
+    // Third pass: normalize
+    coord = vec![0usize; ndim];
+    for flat_i in 0..total {
+        let mut out_idx = 0;
+        for d in 0..ndim {
+            if d != dim {
+                out_idx += coord[d] * out_strides[d];
+            }
+        }
+        result[flat_i] /= exp_sums[out_idx];
+        for d in (0..ndim).rev() {
+            coord[d] += 1;
+            if coord[d] < shape[d] { break; }
+            coord[d] = 0;
+        }
+    }
+
+    Tensor::from_data(result, shape.to_vec())
+}
+
+/// Log-softmax along a dimension.
+pub fn log_softmax(a: &Tensor, dim: usize) -> Tensor {
+    let sm = softmax(a, dim);
+    log(&sm)
+}
+
+// ---- Gather / indexing ----
+
+/// Select elements along a dimension by index.
+/// Like PyTorch's index_select.
+pub fn index_select(a: &Tensor, dim: usize, indices: &[usize]) -> Tensor {
+    let shape = a.shape();
+    assert!(dim < a.ndim());
+    let data = a.contiguous().to_vec();
+    let in_strides = Tensor::compute_contiguous_strides(shape);
+
+    let mut out_shape = shape.to_vec();
+    out_shape[dim] = indices.len();
+    let out_numel: usize = out_shape.iter().product();
+    let out_strides = Tensor::compute_contiguous_strides(&out_shape);
+    let ndim = shape.len();
+
+    let mut result = vec![0.0f32; out_numel];
+    let mut coord = vec![0usize; ndim];
+    for _ in 0..out_numel {
+        let mut out_idx = 0;
+        let mut in_idx = 0;
+        for d in 0..ndim {
+            out_idx += coord[d] * out_strides[d];
+            if d == dim {
+                in_idx += indices[coord[d]] * in_strides[d];
+            } else {
+                in_idx += coord[d] * in_strides[d];
+            }
+        }
+        result[out_idx] = data[in_idx];
+
+        for d in (0..ndim).rev() {
+            coord[d] += 1;
+            if coord[d] < out_shape[d] { break; }
+            coord[d] = 0;
+        }
+    }
+
+    Tensor::from_data(result, out_shape)
+}
+
+// ---- One-hot encoding ----
+
+/// Create one-hot encoded tensor from class indices.
+/// indices: (N,) tensor with class indices, num_classes: number of classes
+/// Returns: (N, num_classes) tensor
+pub fn one_hot(indices: &Tensor, num_classes: usize) -> Tensor {
+    assert_eq!(indices.ndim(), 1, "one_hot requires 1D input");
+    let n = indices.shape()[0];
+    let idx_data = indices.to_vec();
+    let mut result = vec![0.0f32; n * num_classes];
+    for (i, &idx) in idx_data.iter().enumerate() {
+        let c = idx as usize;
+        assert!(c < num_classes, "Class index out of range");
+        result[i * num_classes + c] = 1.0;
+    }
+    Tensor::from_data(result, vec![n, num_classes])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_add() {
+        let a = Tensor::from_data(vec![1.0, 2.0, 3.0], vec![3]);
+        let b = Tensor::from_data(vec![4.0, 5.0, 6.0], vec![3]);
+        let c = add(&a, &b);
+        assert_eq!(c.to_vec(), vec![5.0, 7.0, 9.0]);
+    }
+
+    #[test]
+    fn test_broadcast_add() {
+        let a = Tensor::from_data(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], vec![2, 3]);
+        let b = Tensor::from_data(vec![10.0, 20.0, 30.0], vec![3]);
+        let c = add(&a, &b);
+        assert_eq!(c.shape(), &[2, 3]);
+        assert_eq!(c.to_vec(), vec![11.0, 22.0, 33.0, 14.0, 25.0, 36.0]);
+    }
+
+    #[test]
+    fn test_mul() {
+        let a = Tensor::from_data(vec![2.0, 3.0], vec![2]);
+        let b = Tensor::from_data(vec![4.0, 5.0], vec![2]);
+        let c = mul(&a, &b);
+        assert_eq!(c.to_vec(), vec![8.0, 15.0]);
+    }
+
+    #[test]
+    fn test_neg() {
+        let a = Tensor::from_data(vec![1.0, -2.0, 3.0], vec![3]);
+        let b = neg(&a);
+        assert_eq!(b.to_vec(), vec![-1.0, 2.0, -3.0]);
+    }
+
+    #[test]
+    fn test_exp_log() {
+        let a = Tensor::from_data(vec![0.0, 1.0], vec![2]);
+        let e = exp(&a);
+        assert!((e.get(&[0]) - 1.0).abs() < 1e-6);
+        assert!((e.get(&[1]) - std::f32::consts::E).abs() < 1e-5);
+
+        let l = log(&e);
+        assert!((l.get(&[0]) - 0.0).abs() < 1e-6);
+        assert!((l.get(&[1]) - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_sum() {
+        let a = Tensor::from_data(vec![1.0, 2.0, 3.0, 4.0], vec![2, 2]);
+        let s = sum(&a);
+        assert_eq!(s.item(), 10.0);
+    }
+
+    #[test]
+    fn test_sum_dim() {
+        let a = Tensor::from_data(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], vec![2, 3]);
+        let s0 = sum_dim(&a, 0, false);
+        assert_eq!(s0.shape(), &[3]);
+        assert_eq!(s0.to_vec(), vec![5.0, 7.0, 9.0]);
+
+        let s1 = sum_dim(&a, 1, false);
+        assert_eq!(s1.shape(), &[2]);
+        assert_eq!(s1.to_vec(), vec![6.0, 15.0]);
+
+        let s1k = sum_dim(&a, 1, true);
+        assert_eq!(s1k.shape(), &[2, 1]);
+    }
+
+    #[test]
+    fn test_mean() {
+        let a = Tensor::from_data(vec![1.0, 2.0, 3.0, 4.0], vec![2, 2]);
+        let m = mean(&a);
+        assert_eq!(m.item(), 2.5);
+    }
+
+    #[test]
+    fn test_max_min() {
+        let a = Tensor::from_data(vec![3.0, 1.0, 4.0, 1.0, 5.0, 9.0], vec![6]);
+        assert_eq!(max(&a).item(), 9.0);
+        assert_eq!(min(&a).item(), 1.0);
+    }
+
+    #[test]
+    fn test_matmul() {
+        // [[1,2],[3,4]] x [[5,6],[7,8]] = [[19,22],[43,50]]
+        let a = Tensor::from_data(vec![1.0, 2.0, 3.0, 4.0], vec![2, 2]);
+        let b = Tensor::from_data(vec![5.0, 6.0, 7.0, 8.0], vec![2, 2]);
+        let c = matmul(&a, &b);
+        assert_eq!(c.shape(), &[2, 2]);
+        assert_eq!(c.to_vec(), vec![19.0, 22.0, 43.0, 50.0]);
+    }
+
+    #[test]
+    fn test_matmul_non_square() {
+        // (2,3) x (3,2) = (2,2)
+        let a = Tensor::from_data(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], vec![2, 3]);
+        let b = Tensor::from_data(vec![7.0, 8.0, 9.0, 10.0, 11.0, 12.0], vec![3, 2]);
+        let c = matmul(&a, &b);
+        assert_eq!(c.shape(), &[2, 2]);
+        assert_eq!(c.to_vec(), vec![58.0, 64.0, 139.0, 154.0]);
+    }
+
+    #[test]
+    fn test_relu() {
+        let a = Tensor::from_data(vec![-1.0, 0.0, 1.0, -0.5, 2.0], vec![5]);
+        let r = relu(&a);
+        assert_eq!(r.to_vec(), vec![0.0, 0.0, 1.0, 0.0, 2.0]);
+    }
+
+    #[test]
+    fn test_softmax() {
+        let a = Tensor::from_data(vec![1.0, 2.0, 3.0], vec![1, 3]);
+        let s = softmax(&a, 1);
+        let data = s.to_vec();
+        let total: f32 = data.iter().sum();
+        assert!((total - 1.0).abs() < 1e-5);
+        // values should be increasing
+        assert!(data[0] < data[1]);
+        assert!(data[1] < data[2]);
+    }
+
+    #[test]
+    fn test_argmax() {
+        let a = Tensor::from_data(vec![1.0, 3.0, 2.0, 5.0, 4.0, 6.0], vec![2, 3]);
+        let am = argmax(&a, 1);
+        assert_eq!(am.shape(), &[2]);
+        assert_eq!(am.to_vec(), vec![1.0, 2.0]);
+    }
+
+    #[test]
+    fn test_scalar_ops() {
+        let a = Tensor::from_data(vec![1.0, 2.0, 3.0], vec![3]);
+        let b = add_scalar(&a, 10.0);
+        assert_eq!(b.to_vec(), vec![11.0, 12.0, 13.0]);
+
+        let c = mul_scalar(&a, 2.0);
+        assert_eq!(c.to_vec(), vec![2.0, 4.0, 6.0]);
+    }
+
+    #[test]
+    fn test_one_hot() {
+        let indices = Tensor::from_data(vec![0.0, 2.0, 1.0], vec![3]);
+        let oh = one_hot(&indices, 3);
+        assert_eq!(oh.shape(), &[3, 3]);
+        assert_eq!(oh.to_vec(), vec![
+            1.0, 0.0, 0.0,
+            0.0, 0.0, 1.0,
+            0.0, 1.0, 0.0,
+        ]);
+    }
+}

--- a/crates/cakelamp-core/src/storage.rs
+++ b/crates/cakelamp-core/src/storage.rs
@@ -1,0 +1,31 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// Shared, mutable tensor storage backed by a flat Vec<f32>.
+/// Multiple tensors (views) can share the same Storage via Rc<RefCell<...>>.
+#[derive(Debug, Clone)]
+pub struct Storage {
+    pub data: Vec<f32>,
+}
+
+impl Storage {
+    pub fn new(data: Vec<f32>) -> Rc<RefCell<Self>> {
+        Rc::new(RefCell::new(Storage { data }))
+    }
+
+    pub fn zeros(size: usize) -> Rc<RefCell<Self>> {
+        Self::new(vec![0.0; size])
+    }
+
+    pub fn ones(size: usize) -> Rc<RefCell<Self>> {
+        Self::new(vec![1.0; size])
+    }
+
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+}

--- a/crates/cakelamp-core/src/tensor.rs
+++ b/crates/cakelamp-core/src/tensor.rs
@@ -1,0 +1,625 @@
+use std::cell::RefCell;
+use std::fmt;
+use std::rc::Rc;
+
+use crate::storage::Storage;
+
+/// A multi-dimensional tensor with f32 storage.
+///
+/// Uses a flat Vec<f32> for storage with shape and stride metadata.
+/// Element at index (i0, i1, ..., in) is at:
+///   storage[storage_offset + i0*stride[0] + i1*stride[1] + ... + in*stride[n]]
+///
+/// Views (transpose, reshape) share storage and just change strides/offset.
+#[derive(Debug, Clone)]
+pub struct Tensor {
+    pub(crate) storage: Rc<RefCell<Storage>>,
+    pub(crate) shape: Vec<usize>,
+    pub(crate) strides: Vec<usize>,
+    pub(crate) storage_offset: usize,
+}
+
+impl Tensor {
+    // ---- Constructors ----
+
+    /// Create a tensor from raw data and shape.
+    pub fn from_data(data: Vec<f32>, shape: Vec<usize>) -> Self {
+        let expected: usize = shape.iter().product();
+        assert_eq!(
+            data.len(),
+            expected,
+            "Data length {} does not match shape {:?} (expected {})",
+            data.len(),
+            shape,
+            expected
+        );
+        let strides = Self::compute_contiguous_strides(&shape);
+        Tensor {
+            storage: Storage::new(data),
+            shape,
+            strides,
+            storage_offset: 0,
+        }
+    }
+
+    /// Create a tensor filled with zeros.
+    pub fn zeros(shape: Vec<usize>) -> Self {
+        let size: usize = shape.iter().product();
+        let strides = Self::compute_contiguous_strides(&shape);
+        Tensor {
+            storage: Storage::zeros(size),
+            shape,
+            strides,
+            storage_offset: 0,
+        }
+    }
+
+    /// Create a tensor filled with ones.
+    pub fn ones(shape: Vec<usize>) -> Self {
+        let size: usize = shape.iter().product();
+        let strides = Self::compute_contiguous_strides(&shape);
+        Tensor {
+            storage: Storage::ones(size),
+            shape,
+            strides,
+            storage_offset: 0,
+        }
+    }
+
+    /// Create a tensor filled with a specific value.
+    pub fn full(shape: Vec<usize>, value: f32) -> Self {
+        let size: usize = shape.iter().product();
+        let strides = Self::compute_contiguous_strides(&shape);
+        Tensor {
+            storage: Storage::new(vec![value; size]),
+            shape,
+            strides,
+            storage_offset: 0,
+        }
+    }
+
+    /// Create a tensor with random values in [0, 1).
+    pub fn rand(shape: Vec<usize>) -> Self {
+        use rand::Rng;
+        let size: usize = shape.iter().product();
+        let mut rng = rand::thread_rng();
+        let data: Vec<f32> = (0..size).map(|_| rng.gen::<f32>()).collect();
+        let strides = Self::compute_contiguous_strides(&shape);
+        Tensor {
+            storage: Storage::new(data),
+            shape,
+            strides,
+            storage_offset: 0,
+        }
+    }
+
+    /// Create a tensor with random values from a normal distribution N(0, 1).
+    pub fn randn(shape: Vec<usize>) -> Self {
+        use rand::Rng;
+        let size: usize = shape.iter().product();
+        let mut rng = rand::thread_rng();
+        // Box-Muller transform
+        let data: Vec<f32> = (0..size)
+            .map(|_| {
+                let u1: f64 = rng.gen::<f64>().max(1e-10);
+                let u2: f64 = rng.gen::<f64>();
+                ((-2.0 * u1.ln()).sqrt() * (2.0 * std::f64::consts::PI * u2).cos()) as f32
+            })
+            .collect();
+        let strides = Self::compute_contiguous_strides(&shape);
+        Tensor {
+            storage: Storage::new(data),
+            shape,
+            strides,
+            storage_offset: 0,
+        }
+    }
+
+    /// Create a scalar tensor.
+    pub fn scalar(value: f32) -> Self {
+        Tensor {
+            storage: Storage::new(vec![value]),
+            shape: vec![],
+            strides: vec![],
+            storage_offset: 0,
+        }
+    }
+
+    /// Create a 1-D tensor with values from start to end (exclusive), step 1.
+    pub fn arange(start: f32, end: f32, step: f32) -> Self {
+        let mut data = Vec::new();
+        let mut val = start;
+        if step > 0.0 {
+            while val < end {
+                data.push(val);
+                val += step;
+            }
+        } else if step < 0.0 {
+            while val > end {
+                data.push(val);
+                val += step;
+            }
+        }
+        let len = data.len();
+        Self::from_data(data, vec![len])
+    }
+
+    // ---- Properties ----
+
+    pub fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+
+    pub fn strides(&self) -> &[usize] {
+        &self.strides
+    }
+
+    pub fn ndim(&self) -> usize {
+        self.shape.len()
+    }
+
+    pub fn numel(&self) -> usize {
+        self.shape.iter().product()
+    }
+
+    pub fn storage_offset(&self) -> usize {
+        self.storage_offset
+    }
+
+    /// Whether this tensor is contiguous in memory (C-order).
+    pub fn is_contiguous(&self) -> bool {
+        if self.shape.is_empty() {
+            return true;
+        }
+        let expected = Self::compute_contiguous_strides(&self.shape);
+        self.strides == expected
+    }
+
+    // ---- Data Access ----
+
+    /// Get the flat index into storage for given multi-dimensional indices.
+    pub fn flat_index(&self, indices: &[usize]) -> usize {
+        assert_eq!(indices.len(), self.ndim(), "Wrong number of indices");
+        let mut idx = self.storage_offset;
+        for (i, &dim_idx) in indices.iter().enumerate() {
+            assert!(dim_idx < self.shape[i], "Index out of bounds");
+            idx += dim_idx * self.strides[i];
+        }
+        idx
+    }
+
+    /// Get an element by multi-dimensional index.
+    pub fn get(&self, indices: &[usize]) -> f32 {
+        let idx = self.flat_index(indices);
+        self.storage.borrow().data[idx]
+    }
+
+    /// Set an element by multi-dimensional index.
+    pub fn set(&self, indices: &[usize], value: f32) {
+        let idx = self.flat_index(indices);
+        self.storage.borrow_mut().data[idx] = value;
+    }
+
+    /// Get scalar value (for 0-dim tensors).
+    pub fn item(&self) -> f32 {
+        assert!(self.numel() == 1, "item() requires a single-element tensor");
+        self.storage.borrow().data[self.storage_offset]
+    }
+
+    /// Return a contiguous copy of data in row-major order.
+    pub fn to_vec(&self) -> Vec<f32> {
+        let n = self.numel();
+        if n == 0 {
+            return vec![];
+        }
+        let mut result = Vec::with_capacity(n);
+        let storage = self.storage.borrow();
+        self.collect_data(&storage.data, &self.shape, &self.strides, self.storage_offset, &mut result);
+        result
+    }
+
+    fn collect_data(
+        &self,
+        data: &[f32],
+        shape: &[usize],
+        strides: &[usize],
+        offset: usize,
+        result: &mut Vec<f32>,
+    ) {
+        if shape.is_empty() {
+            result.push(data[offset]);
+            return;
+        }
+        if shape.len() == 1 {
+            for i in 0..shape[0] {
+                result.push(data[offset + i * strides[0]]);
+            }
+            return;
+        }
+        for i in 0..shape[0] {
+            self.collect_data(data, &shape[1..], &strides[1..], offset + i * strides[0], result);
+        }
+    }
+
+    /// Return a new contiguous tensor with the same data.
+    pub fn contiguous(&self) -> Tensor {
+        if self.is_contiguous() {
+            return self.clone();
+        }
+        Tensor::from_data(self.to_vec(), self.shape.clone())
+    }
+
+    // ---- Views (share storage) ----
+
+    /// Reshape the tensor (must be contiguous). Returns a view sharing storage.
+    pub fn reshape(&self, new_shape: Vec<usize>) -> Tensor {
+        let mut resolved = new_shape.clone();
+        let mut infer_idx = None;
+        let mut known_product: usize = 1;
+
+        for (i, &dim) in resolved.iter().enumerate() {
+            if dim == usize::MAX {
+                // Use usize::MAX as -1 sentinel
+                assert!(infer_idx.is_none(), "Can only infer one dimension");
+                infer_idx = Some(i);
+            } else {
+                known_product *= dim;
+            }
+        }
+
+        if let Some(idx) = infer_idx {
+            assert!(
+                self.numel() % known_product == 0,
+                "Cannot reshape tensor of size {} into {:?}",
+                self.numel(),
+                new_shape
+            );
+            resolved[idx] = self.numel() / known_product;
+        }
+
+        let new_numel: usize = resolved.iter().product();
+        assert_eq!(
+            new_numel,
+            self.numel(),
+            "Cannot reshape tensor of size {} into {:?}",
+            self.numel(),
+            resolved
+        );
+
+        // Must be contiguous for simple reshape view
+        if self.is_contiguous() {
+            let strides = Self::compute_contiguous_strides(&resolved);
+            Tensor {
+                storage: Rc::clone(&self.storage),
+                shape: resolved,
+                strides,
+                storage_offset: self.storage_offset,
+            }
+        } else {
+            // Make contiguous copy, then reshape
+            let t = self.contiguous();
+            let strides = Self::compute_contiguous_strides(&resolved);
+            Tensor {
+                storage: t.storage,
+                shape: resolved,
+                strides,
+                storage_offset: 0,
+            }
+        }
+    }
+
+    /// Transpose two dimensions. Returns a view sharing storage.
+    pub fn transpose(&self, dim0: usize, dim1: usize) -> Tensor {
+        assert!(dim0 < self.ndim() && dim1 < self.ndim(), "Dimension out of range");
+        let mut new_shape = self.shape.clone();
+        let mut new_strides = self.strides.clone();
+        new_shape.swap(dim0, dim1);
+        new_strides.swap(dim0, dim1);
+        Tensor {
+            storage: Rc::clone(&self.storage),
+            shape: new_shape,
+            strides: new_strides,
+            storage_offset: self.storage_offset,
+        }
+    }
+
+    /// Shorthand for transpose(0, 1) on a 2D tensor. Commonly `.t()`.
+    pub fn t(&self) -> Tensor {
+        assert!(self.ndim() == 2, "t() requires a 2D tensor");
+        self.transpose(0, 1)
+    }
+
+    /// Unsqueeze: add a dimension of size 1 at the given position.
+    pub fn unsqueeze(&self, dim: usize) -> Tensor {
+        assert!(dim <= self.ndim(), "Dimension out of range for unsqueeze");
+        let mut new_shape = self.shape.clone();
+        let mut new_strides = self.strides.clone();
+        // The stride for a size-1 dim doesn't matter (could be anything), use 1
+        let stride_val = if dim < self.ndim() { self.strides[dim] } else { 1 };
+        new_shape.insert(dim, 1);
+        new_strides.insert(dim, stride_val);
+        Tensor {
+            storage: Rc::clone(&self.storage),
+            shape: new_shape,
+            strides: new_strides,
+            storage_offset: self.storage_offset,
+        }
+    }
+
+    /// Squeeze: remove all dimensions of size 1 (or a specific dimension).
+    pub fn squeeze(&self, dim: Option<usize>) -> Tensor {
+        let mut new_shape = Vec::new();
+        let mut new_strides = Vec::new();
+        for (i, (&s, &st)) in self.shape.iter().zip(self.strides.iter()).enumerate() {
+            let should_squeeze = match dim {
+                Some(d) => i == d && s == 1,
+                None => s == 1,
+            };
+            if !should_squeeze {
+                new_shape.push(s);
+                new_strides.push(st);
+            }
+        }
+        Tensor {
+            storage: Rc::clone(&self.storage),
+            shape: new_shape,
+            strides: new_strides,
+            storage_offset: self.storage_offset,
+        }
+    }
+
+    /// Expand tensor to a larger size (broadcasting). Expanded dims must be size 1.
+    pub fn expand(&self, new_shape: &[usize]) -> Tensor {
+        assert!(
+            new_shape.len() >= self.ndim(),
+            "Expanded shape must have at least as many dimensions"
+        );
+        let offset = new_shape.len() - self.ndim();
+        let mut result_strides = vec![0usize; new_shape.len()];
+
+        for i in 0..new_shape.len() {
+            if i < offset {
+                result_strides[i] = 0;
+            } else {
+                let orig = i - offset;
+                if self.shape[orig] == new_shape[i] {
+                    result_strides[i] = self.strides[orig];
+                } else if self.shape[orig] == 1 {
+                    result_strides[i] = 0;
+                } else {
+                    panic!(
+                        "Cannot expand dim {} from {} to {}",
+                        orig, self.shape[orig], new_shape[i]
+                    );
+                }
+            }
+        }
+
+        Tensor {
+            storage: Rc::clone(&self.storage),
+            shape: new_shape.to_vec(),
+            strides: result_strides,
+            storage_offset: self.storage_offset,
+        }
+    }
+
+    // ---- In-place ops ----
+
+    /// In-place addition: self += other (element-wise with broadcasting).
+    pub fn add_(&self, other: &Tensor) {
+        let data = self.to_vec();
+        let other_data = other.to_vec();
+        // Simple case: same numel
+        assert_eq!(data.len(), other_data.len(), "add_ requires same size tensors (use broadcast first)");
+        let mut storage = self.storage.borrow_mut();
+        for (i, &v) in other_data.iter().enumerate() {
+            storage.data[self.storage_offset + i] += v;
+        }
+    }
+
+    /// In-place scalar multiplication: self *= scalar.
+    pub fn mul_scalar_(&self, scalar: f32) {
+        if self.is_contiguous() {
+            let mut storage = self.storage.borrow_mut();
+            let start = self.storage_offset;
+            let end = start + self.numel();
+            for v in &mut storage.data[start..end] {
+                *v *= scalar;
+            }
+        } else {
+            let n = self.numel();
+            let indices = self.all_indices();
+            let mut storage = self.storage.borrow_mut();
+            for idx in indices.iter().take(n) {
+                storage.data[*idx] *= scalar;
+            }
+        }
+    }
+
+    /// In-place fill with scalar.
+    pub fn fill_(&self, value: f32) {
+        if self.is_contiguous() {
+            let mut storage = self.storage.borrow_mut();
+            let start = self.storage_offset;
+            let end = start + self.numel();
+            for v in &mut storage.data[start..end] {
+                *v = value;
+            }
+        } else {
+            let indices = self.all_indices();
+            let mut storage = self.storage.borrow_mut();
+            for idx in &indices {
+                storage.data[*idx] = value;
+            }
+        }
+    }
+
+    /// In-place subtraction of scaled tensor: self -= alpha * other
+    pub fn sub_alpha_(&self, other: &Tensor, alpha: f32) {
+        let self_data = self.to_vec();
+        let other_data = other.to_vec();
+        assert_eq!(self_data.len(), other_data.len());
+        let mut storage = self.storage.borrow_mut();
+        for (i, &v) in other_data.iter().enumerate() {
+            storage.data[self.storage_offset + i] -= alpha * v;
+        }
+    }
+
+    /// Copy data from another tensor into self.
+    pub fn copy_from(&self, src: &Tensor) {
+        let data = src.to_vec();
+        assert_eq!(self.numel(), data.len());
+        let mut storage = self.storage.borrow_mut();
+        if self.is_contiguous() {
+            let start = self.storage_offset;
+            storage.data[start..start + data.len()].copy_from_slice(&data);
+        } else {
+            let indices = self.all_indices();
+            for (i, &idx) in indices.iter().enumerate() {
+                storage.data[idx] = data[i];
+            }
+        }
+    }
+
+    // ---- Helpers ----
+
+    /// Compute contiguous (row-major) strides from shape.
+    pub fn compute_contiguous_strides(shape: &[usize]) -> Vec<usize> {
+        if shape.is_empty() {
+            return vec![];
+        }
+        let mut strides = vec![0usize; shape.len()];
+        strides[shape.len() - 1] = 1;
+        for i in (0..shape.len() - 1).rev() {
+            strides[i] = strides[i + 1] * shape[i + 1];
+        }
+        strides
+    }
+
+    /// Get all flat storage indices in row-major order.
+    fn all_indices(&self) -> Vec<usize> {
+        let n = self.numel();
+        let mut indices = Vec::with_capacity(n);
+        if n == 0 {
+            return indices;
+        }
+        let ndim = self.ndim();
+        if ndim == 0 {
+            indices.push(self.storage_offset);
+            return indices;
+        }
+        let mut coord = vec![0usize; ndim];
+        for _ in 0..n {
+            let mut idx = self.storage_offset;
+            for d in 0..ndim {
+                idx += coord[d] * self.strides[d];
+            }
+            indices.push(idx);
+            // increment coord
+            for d in (0..ndim).rev() {
+                coord[d] += 1;
+                if coord[d] < self.shape[d] {
+                    break;
+                }
+                coord[d] = 0;
+            }
+        }
+        indices
+    }
+}
+
+impl fmt::Display for Tensor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let data = self.to_vec();
+        write!(f, "Tensor(shape={:?}, data={:?})", self.shape, data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_data() {
+        let t = Tensor::from_data(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], vec![2, 3]);
+        assert_eq!(t.shape(), &[2, 3]);
+        assert_eq!(t.ndim(), 2);
+        assert_eq!(t.numel(), 6);
+        assert!(t.is_contiguous());
+    }
+
+    #[test]
+    fn test_get_set() {
+        let t = Tensor::from_data(vec![1.0, 2.0, 3.0, 4.0], vec![2, 2]);
+        assert_eq!(t.get(&[0, 0]), 1.0);
+        assert_eq!(t.get(&[0, 1]), 2.0);
+        assert_eq!(t.get(&[1, 0]), 3.0);
+        assert_eq!(t.get(&[1, 1]), 4.0);
+
+        t.set(&[1, 1], 42.0);
+        assert_eq!(t.get(&[1, 1]), 42.0);
+    }
+
+    #[test]
+    fn test_zeros_ones() {
+        let z = Tensor::zeros(vec![3, 4]);
+        assert_eq!(z.numel(), 12);
+        assert_eq!(z.get(&[0, 0]), 0.0);
+
+        let o = Tensor::ones(vec![2, 2]);
+        assert_eq!(o.get(&[1, 1]), 1.0);
+    }
+
+    #[test]
+    fn test_transpose() {
+        let t = Tensor::from_data(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], vec![2, 3]);
+        let tt = t.t();
+        assert_eq!(tt.shape(), &[3, 2]);
+        assert_eq!(tt.get(&[0, 0]), 1.0);
+        assert_eq!(tt.get(&[0, 1]), 4.0);
+        assert_eq!(tt.get(&[1, 0]), 2.0);
+        assert_eq!(tt.get(&[2, 1]), 6.0);
+        assert!(!tt.is_contiguous());
+    }
+
+    #[test]
+    fn test_reshape() {
+        let t = Tensor::from_data(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], vec![2, 3]);
+        let r = t.reshape(vec![3, 2]);
+        assert_eq!(r.shape(), &[3, 2]);
+        assert_eq!(r.get(&[0, 0]), 1.0);
+        assert_eq!(r.get(&[2, 1]), 6.0);
+    }
+
+    #[test]
+    fn test_to_vec() {
+        let t = Tensor::from_data(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], vec![2, 3]);
+        let tt = t.t();
+        let data = tt.to_vec();
+        assert_eq!(data, vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+    }
+
+    #[test]
+    fn test_scalar() {
+        let s = Tensor::scalar(3.14);
+        assert_eq!(s.ndim(), 0);
+        assert_eq!(s.numel(), 1);
+        assert_eq!(s.item(), 3.14);
+    }
+
+    #[test]
+    fn test_unsqueeze_squeeze() {
+        let t = Tensor::from_data(vec![1.0, 2.0, 3.0], vec![3]);
+        let u = t.unsqueeze(0);
+        assert_eq!(u.shape(), &[1, 3]);
+        let s = u.squeeze(None);
+        assert_eq!(s.shape(), &[3]);
+    }
+
+    #[test]
+    fn test_arange() {
+        let t = Tensor::arange(0.0, 5.0, 1.0);
+        assert_eq!(t.shape(), &[5]);
+        assert_eq!(t.to_vec(), vec![0.0, 1.0, 2.0, 3.0, 4.0]);
+    }
+}


### PR DESCRIPTION
## Summary
- Complete Rust linear algebra backend (`cakelamp-core` crate) with f32-only storage
- Tensor struct with flat Vec<f32>, shape/stride metadata, and storage_offset for views
- Element-wise ops (add, sub, mul, div, neg, exp, log, relu, sigmoid, tanh) with broadcasting
- Reduction ops (sum, mean, max, min, argmax) with dimension and keepdim support
- Matrix multiplication (matmul, bmm) and softmax/log_softmax
- View operations (transpose, reshape, unsqueeze, squeeze, expand) sharing storage
- In-place ops (add_, mul_scalar_, fill_, sub_alpha_, copy_from)
- Tensor creation (zeros, ones, full, rand, randn, arange, scalar)
- 29 tests all passing

Closes #1

## Build times
- cargo build: 16s
- cargo test: 0.3s (29 tests)

## Test plan
- [x] All 29 unit tests pass
- [x] Broadcasting correctness verified
- [x] Matmul correctness verified
- [x] View sharing (transpose, reshape) verified