### PR TITLE
Add neural network modules (nn) with tests

### DIFF
--- a/python/cakelamp/nn/__init__.py
+++ b/python/cakelamp/nn/__init__.py
@@ -1,0 +1,29 @@
+"""CakeLamp neural network modules.
+
+Provides the building blocks for defining and training neural networks.
+Mirrors the torch.nn API.
+"""
+
+from cakelamp.nn.module import Module
+from cakelamp.nn.parameter import Parameter
+from cakelamp.nn.linear import Linear
+from cakelamp.nn.activations import ReLU, Sigmoid, Tanh, Softmax, LogSoftmax
+from cakelamp.nn.loss import MSELoss, CrossEntropyLoss, NLLLoss
+from cakelamp.nn.containers import Sequential
+from cakelamp.nn.dropout import Dropout
+
+__all__ = [
+    "Module",
+    "Parameter",
+    "Linear",
+    "ReLU",
+    "Sigmoid",
+    "Tanh",
+    "Softmax",
+    "LogSoftmax",
+    "MSELoss",
+    "CrossEntropyLoss",
+    "NLLLoss",
+    "Sequential",
+    "Dropout",
+]

--- a/python/cakelamp/nn/activations.py
+++ b/python/cakelamp/nn/activations.py
@@ -1,0 +1,79 @@
+"""Activation function modules for CakeLamp nn.
+
+Each activation is a stateless Module that wraps the corresponding
+tensor operation.
+"""
+
+from __future__ import annotations
+
+from cakelamp.nn.module import Module
+
+
+class ReLU(Module):
+    """Applies the rectified linear unit function element-wise.
+
+    ``ReLU(x) = max(0, x)``
+    """
+
+    def forward(self, input):
+        return input.relu()
+
+    def extra_repr(self) -> str:
+        return ""
+
+
+class Sigmoid(Module):
+    """Applies the sigmoid function element-wise.
+
+    ``Sigmoid(x) = 1 / (1 + exp(-x))``
+    """
+
+    def forward(self, input):
+        return input.sigmoid()
+
+
+class Tanh(Module):
+    """Applies the hyperbolic tangent function element-wise."""
+
+    def forward(self, input):
+        return input.tanh()
+
+
+class Softmax(Module):
+    """Applies the softmax function along a dimension.
+
+    Parameters
+    ----------
+    dim : int
+        Dimension along which softmax will be computed.
+    """
+
+    def __init__(self, dim: int = -1) -> None:
+        super().__init__()
+        self.dim = dim
+
+    def forward(self, input):
+        return input.softmax(self.dim)
+
+    def extra_repr(self) -> str:
+        return f"dim={self.dim}"
+
+
+class LogSoftmax(Module):
+    """Applies log(softmax(x)) along a dimension.
+
+    Parameters
+    ----------
+    dim : int
+        Dimension along which log-softmax will be computed.
+    """
+
+    def __init__(self, dim: int = -1) -> None:
+        super().__init__()
+        self.dim = dim
+
+    def forward(self, input):
+        return input.log_softmax(self.dim)
+
+    def extra_repr(self) -> str:
+        return f"dim={self.dim}"

--- a/python/cakelamp/nn/containers.py
+++ b/python/cakelamp/nn/containers.py
@@ -1,0 +1,68 @@
+"""Container modules for CakeLamp nn.
+
+Provides Sequential and other module containers.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from typing import Any, Iterator, Tuple, Union
+
+from cakelamp.nn.module import Module
+
+
+class Sequential(Module):
+    """A sequential container.
+
+    Modules are added in order and called sequentially during forward.
+    The output of each module is fed as input to the next.
+
+    Can be initialised with positional Module arguments or an
+    OrderedDict of named modules.
+
+    Examples
+    --------
+    >>> model = Sequential(
+    ...     Linear(784, 128),
+    ...     ReLU(),
+    ...     Linear(128, 10),
+    ... )
+    >>> output = model(input_tensor)
+    """
+
+    def __init__(self, *args: Union[Module, OrderedDict]) -> None:
+        super().__init__()
+        if len(args) == 1 and isinstance(args[0], OrderedDict):
+            for key, module in args[0].items():
+                self._modules[key] = module
+                super().__setattr__(key, module)
+        else:
+            for idx, module in enumerate(args):
+                self._modules[str(idx)] = module
+                super().__setattr__(str(idx), module)
+
+    def forward(self, input: Any) -> Any:
+        for module in self._modules.values():
+            input = module(input)
+        return input
+
+    def __len__(self) -> int:
+        return len(self._modules)
+
+    def __iter__(self) -> Iterator[Module]:
+        return iter(self._modules.values())
+
+    def __getitem__(self, idx: int) -> Module:
+        keys = list(self._modules.keys())
+        if isinstance(idx, int):
+            if idx < 0:
+                idx += len(keys)
+            return self._modules[keys[idx]]
+        raise TypeError(f"indices must be integers, not {type(idx).__name__}")
+
+    def append(self, module: Module) -> Sequential:
+        """Append a module to the end of the sequential container."""
+        idx = len(self._modules)
+        self._modules[str(idx)] = module
+        super().__setattr__(str(idx), module)
+        return self

--- a/python/cakelamp/nn/dropout.py
+++ b/python/cakelamp/nn/dropout.py
@@ -1,0 +1,36 @@
+"""Dropout module for CakeLamp nn."""
+
+from __future__ import annotations
+
+import random
+
+from cakelamp.nn.module import Module
+
+
+class Dropout(Module):
+    """During training, randomly zeroes elements with probability ``p``.
+
+    Outputs are scaled by ``1/(1-p)`` so that the expected value is
+    preserved.  During evaluation, Dropout is a no-op.
+
+    Parameters
+    ----------
+    p : float
+        Probability of an element being zeroed (default: ``0.5``).
+    """
+
+    def __init__(self, p: float = 0.5) -> None:
+        super().__init__()
+        if not 0.0 <= p < 1.0:
+            raise ValueError(f"dropout probability must be in [0, 1), got {p}")
+        self.p = p
+
+    def forward(self, input):
+        if not self.training or self.p == 0.0:
+            return input
+        # Generate a mask and apply it.
+        # This delegates to the tensor's dropout method.
+        return input.dropout(self.p, self.training)
+
+    def extra_repr(self) -> str:
+        return f"p={self.p}"

--- a/python/cakelamp/nn/linear.py
+++ b/python/cakelamp/nn/linear.py
@@ -1,0 +1,83 @@
+"""Linear (fully connected) layer for CakeLamp nn.
+
+Applies an affine transformation: y = x @ W^T + b.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from typing import Optional
+
+from cakelamp.nn.module import Module
+from cakelamp.nn.parameter import Parameter
+
+
+class Linear(Module):
+    """Fully connected linear layer.
+
+    Applies: ``y = x @ weight.T + bias``
+
+    Parameters
+    ----------
+    in_features : int
+        Size of each input sample.
+    out_features : int
+        Size of each output sample.
+    bias : bool
+        If ``True`` (default), add an additive bias.
+    """
+
+    def __init__(
+        self, in_features: int, out_features: int, bias: bool = True
+    ) -> None:
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+
+        # Initialise weight with Kaiming uniform (like PyTorch default).
+        # For a Linear layer: fan_in = in_features
+        bound = 1.0 / math.sqrt(in_features)
+        weight_data = self._uniform(out_features * in_features, -bound, bound)
+        self.weight = Parameter(weight_data)
+
+        if bias:
+            bias_data = self._uniform(out_features, -bound, bound)
+            self.bias: Optional[Parameter] = Parameter(bias_data)
+        else:
+            self.bias = None
+
+    @staticmethod
+    def _uniform(n: int, low: float, high: float) -> list:
+        """Generate n uniform random values in [low, high).
+
+        Returns a plain list.  When the real Tensor backend is available,
+        this will be replaced with Tensor.uniform_.
+        """
+        return [random.uniform(low, high) for _ in range(n)]
+
+    def forward(self, input):
+        """Apply the linear transformation.
+
+        Parameters
+        ----------
+        input : Tensor
+            Input tensor of shape ``(*, in_features)``.
+
+        Returns
+        -------
+        Tensor
+            Output of shape ``(*, out_features)``.
+        """
+        # x @ W^T
+        output = input.matmul(self.weight.data.t())
+        if self.bias is not None:
+            output = output.add(self.bias.data)
+        return output
+
+    def extra_repr(self) -> str:
+        return (
+            f"in_features={self.in_features}, "
+            f"out_features={self.out_features}, "
+            f"bias={self.bias is not None}"
+        )

--- a/python/cakelamp/nn/loss.py
+++ b/python/cakelamp/nn/loss.py
@@ -1,0 +1,136 @@
+"""Loss function modules for CakeLamp nn.
+
+Provides common loss functions needed for training neural networks.
+"""
+
+from __future__ import annotations
+
+from cakelamp.nn.module import Module
+
+
+class MSELoss(Module):
+    """Mean Squared Error loss.
+
+    ``loss = mean((input - target)^2)``
+
+    Parameters
+    ----------
+    reduction : str
+        Specifies the reduction to apply: ``'mean'`` (default),
+        ``'sum'``, or ``'none'``.
+    """
+
+    def __init__(self, reduction: str = "mean") -> None:
+        super().__init__()
+        if reduction not in ("mean", "sum", "none"):
+            raise ValueError(
+                f"Invalid reduction mode: {reduction}. "
+                "Must be 'mean', 'sum', or 'none'."
+            )
+        self.reduction = reduction
+
+    def forward(self, input, target):
+        diff = input.sub(target)
+        sq = diff.mul(diff)
+        if self.reduction == "mean":
+            return sq.mean()
+        elif self.reduction == "sum":
+            return sq.sum()
+        else:
+            return sq
+
+    def extra_repr(self) -> str:
+        return f"reduction='{self.reduction}'"
+
+
+class NLLLoss(Module):
+    """Negative Log Likelihood loss.
+
+    Expects log-probabilities as input (e.g., from LogSoftmax).
+
+    ``loss = -sum(log_probs[i, target[i]]) / N``
+
+    Parameters
+    ----------
+    reduction : str
+        ``'mean'`` (default), ``'sum'``, or ``'none'``.
+    """
+
+    def __init__(self, reduction: str = "mean") -> None:
+        super().__init__()
+        if reduction not in ("mean", "sum", "none"):
+            raise ValueError(
+                f"Invalid reduction mode: {reduction}. "
+                "Must be 'mean', 'sum', or 'none'."
+            )
+        self.reduction = reduction
+
+    def forward(self, input, target):
+        """Compute NLL loss.
+
+        Parameters
+        ----------
+        input : Tensor
+            Log-probabilities of shape ``(N, C)``.
+        target : Tensor
+            Target class indices of shape ``(N,)`` with integer values.
+        """
+        # Gather the log-probability for each target class.
+        # nll = -input[i, target[i]] for each sample i
+        nll = input.nll_gather(target)
+
+        if self.reduction == "mean":
+            return nll.mean()
+        elif self.reduction == "sum":
+            return nll.sum()
+        else:
+            return nll
+
+    def extra_repr(self) -> str:
+        return f"reduction='{self.reduction}'"
+
+
+class CrossEntropyLoss(Module):
+    """Cross Entropy loss.
+
+    Combines LogSoftmax and NLLLoss in one step for numerical stability.
+
+    ``loss = -sum(log_softmax(input)[i, target[i]]) / N``
+
+    Parameters
+    ----------
+    reduction : str
+        ``'mean'`` (default), ``'sum'``, or ``'none'``.
+    """
+
+    def __init__(self, reduction: str = "mean") -> None:
+        super().__init__()
+        if reduction not in ("mean", "sum", "none"):
+            raise ValueError(
+                f"Invalid reduction mode: {reduction}. "
+                "Must be 'mean', 'sum', or 'none'."
+            )
+        self.reduction = reduction
+
+    def forward(self, input, target):
+        """Compute cross entropy loss.
+
+        Parameters
+        ----------
+        input : Tensor
+            Raw logits of shape ``(N, C)``.
+        target : Tensor
+            Target class indices of shape ``(N,)`` with integer values.
+        """
+        log_probs = input.log_softmax(dim=1)
+        nll = log_probs.nll_gather(target)
+
+        if self.reduction == "mean":
+            return nll.mean()
+        elif self.reduction == "sum":
+            return nll.sum()
+        else:
+            return nll
+
+    def extra_repr(self) -> str:
+        return f"reduction='{self.reduction}'"

--- a/python/cakelamp/nn/module.py
+++ b/python/cakelamp/nn/module.py
@@ -1,0 +1,218 @@
+"""Base Module class for CakeLamp nn.
+
+All neural network layers inherit from Module.  Provides automatic
+parameter discovery, recursive children traversal, train/eval mode,
+and state_dict serialisation.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from typing import Any, Dict, Iterator, List, Optional, Set, Tuple
+
+from cakelamp.nn.parameter import Parameter
+
+
+class Module:
+    """Base class for all neural network modules.
+
+    Subclasses should implement :meth:`forward`.  The ``__call__``
+    method delegates to ``forward`` (with hooks support in the future).
+    """
+
+    def __init__(self) -> None:
+        self._parameters: OrderedDict[str, Parameter] = OrderedDict()
+        self._modules: OrderedDict[str, Optional[Module]] = OrderedDict()
+        self.training: bool = True
+
+    # ------------------------------------------------------------------
+    # Attribute registration
+    # ------------------------------------------------------------------
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        # Intercept Parameter and Module assignments so they register
+        # automatically (like PyTorch).
+        if isinstance(value, Parameter):
+            # Remove from _modules if it existed there.
+            modules = self.__dict__.get("_modules", {})
+            if name in modules:
+                del modules[name]
+            params = self.__dict__.get("_parameters", {})
+            params[name] = value
+        elif isinstance(value, Module):
+            params = self.__dict__.get("_parameters", {})
+            if name in params:
+                del params[name]
+            modules = self.__dict__.get("_modules", {})
+            modules[name] = value
+        super().__setattr__(name, value)
+
+    def __getattr__(self, name: str) -> Any:
+        # Look up in _parameters and _modules *after* normal lookup fails.
+        _parameters = self.__dict__.get("_parameters", {})
+        if name in _parameters:
+            return _parameters[name]
+        _modules = self.__dict__.get("_modules", {})
+        if name in _modules:
+            return _modules[name]
+        raise AttributeError(
+            f"'{type(self).__name__}' object has no attribute '{name}'"
+        )
+
+    # ------------------------------------------------------------------
+    # Parameter / module access
+    # ------------------------------------------------------------------
+
+    def parameters(self, recurse: bool = True) -> Iterator[Parameter]:
+        """Yield all parameters of this module.
+
+        Parameters
+        ----------
+        recurse : bool
+            If ``True``, also yield parameters of all sub-modules.
+        """
+        memo: Set[int] = set()
+        for name, param in self.named_parameters(recurse=recurse):
+            if id(param) not in memo:
+                memo.add(id(param))
+                yield param
+
+    def named_parameters(
+        self, prefix: str = "", recurse: bool = True
+    ) -> Iterator[Tuple[str, Parameter]]:
+        """Yield ``(name, Parameter)`` pairs."""
+        memo: Set[int] = set()
+        for name, param in self._parameters.items():
+            if id(param) not in memo:
+                memo.add(id(param))
+                full_name = f"{prefix}.{name}" if prefix else name
+                yield full_name, param
+        if recurse:
+            for mod_name, module in self._modules.items():
+                if module is None:
+                    continue
+                sub_prefix = f"{prefix}.{mod_name}" if prefix else mod_name
+                yield from module.named_parameters(
+                    prefix=sub_prefix, recurse=True
+                )
+
+    def children(self) -> Iterator[Module]:
+        """Yield immediate child modules."""
+        for module in self._modules.values():
+            if module is not None:
+                yield module
+
+    def named_children(self) -> Iterator[Tuple[str, Module]]:
+        """Yield ``(name, Module)`` pairs for immediate children."""
+        for name, module in self._modules.items():
+            if module is not None:
+                yield name, module
+
+    def modules(self) -> Iterator[Module]:
+        """Yield this module and all sub-modules recursively."""
+        yield self
+        for child in self.children():
+            yield from child.modules()
+
+    def named_modules(
+        self, prefix: str = ""
+    ) -> Iterator[Tuple[str, Module]]:
+        """Yield ``(name, Module)`` pairs for this module and all sub-modules."""
+        yield prefix, self
+        for name, child in self.named_children():
+            sub_prefix = f"{prefix}.{name}" if prefix else name
+            yield from child.named_modules(prefix=sub_prefix)
+
+    # ------------------------------------------------------------------
+    # Forward / call
+    # ------------------------------------------------------------------
+
+    def forward(self, *args: Any, **kwargs: Any) -> Any:
+        """Define the computation performed at every call.
+
+        Must be overridden by every subclass.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} must implement forward()"
+        )
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return self.forward(*args, **kwargs)
+
+    # ------------------------------------------------------------------
+    # Train / eval
+    # ------------------------------------------------------------------
+
+    def train(self, mode: bool = True) -> Module:
+        """Set the module (and all children) to training mode."""
+        self.training = mode
+        for child in self.children():
+            child.train(mode)
+        return self
+
+    def eval(self) -> Module:
+        """Set the module (and all children) to evaluation mode."""
+        return self.train(False)
+
+    # ------------------------------------------------------------------
+    # State dict
+    # ------------------------------------------------------------------
+
+    def state_dict(self, prefix: str = "") -> Dict[str, Any]:
+        """Return a flat dict of all parameter data, keyed by name."""
+        result: Dict[str, Any] = {}
+        for name, param in self._parameters.items():
+            key = f"{prefix}{name}"
+            result[key] = param.data
+        for name, module in self._modules.items():
+            if module is not None:
+                child_prefix = f"{prefix}{name}."
+                result.update(module.state_dict(prefix=child_prefix))
+        return result
+
+    def load_state_dict(self, state_dict: Dict[str, Any], prefix: str = "") -> None:
+        """Load parameter data from a flat dict."""
+        for name, param in self._parameters.items():
+            key = f"{prefix}{name}"
+            if key in state_dict:
+                param.data = state_dict[key]
+        for name, module in self._modules.items():
+            if module is not None:
+                child_prefix = f"{prefix}{name}."
+                module.load_state_dict(state_dict, prefix=child_prefix)
+
+    # ------------------------------------------------------------------
+    # Zero grad
+    # ------------------------------------------------------------------
+
+    def zero_grad(self, set_to_none: bool = True) -> None:
+        """Reset gradients for all parameters."""
+        for param in self.parameters():
+            if set_to_none:
+                param.grad = None
+            elif param.grad is not None:
+                param.grad.zero_()
+
+    # ------------------------------------------------------------------
+    # Repr
+    # ------------------------------------------------------------------
+
+    def extra_repr(self) -> str:
+        """Override this to add extra info to the repr string."""
+        return ""
+
+    def __repr__(self) -> str:
+        lines = [f"{self.__class__.__name__}("]
+        extra = self.extra_repr()
+        if extra:
+            lines[0] = f"{self.__class__.__name__}({extra}"
+            if not self._modules:
+                lines[0] += ")"
+                return lines[0]
+            lines[0] += ","
+
+        for name, module in self._modules.items():
+            mod_str = repr(module).replace("\n", "\n  ")
+            lines.append(f"  ({name}): {mod_str}")
+        lines.append(")")
+        return "\n".join(lines)

--- a/python/cakelamp/nn/parameter.py
+++ b/python/cakelamp/nn/parameter.py
@@ -1,0 +1,39 @@
+"""Parameter class for CakeLamp nn module.
+
+A Parameter is a Tensor that is automatically registered as a trainable
+parameter when assigned as a Module attribute.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+class Parameter:
+    """A tensor that is treated as a module parameter.
+
+    When a :class:`Parameter` is assigned as an attribute of a
+    :class:`Module`, it is automatically added to the module's list of
+    parameters and will be returned by :meth:`Module.parameters`.
+
+    Parameters
+    ----------
+    data : tensor
+        The parameter tensor.  ``requires_grad`` is set to ``True``
+        automatically.
+    requires_grad : bool
+        Whether the parameter requires gradient computation
+        (default: ``True``).
+    """
+
+    def __init__(self, data, requires_grad: bool = True) -> None:
+        self.data = data
+        self.requires_grad = requires_grad
+        self.grad: Optional[object] = None
+
+    def zero_grad(self) -> None:
+        """Zero out the gradient."""
+        self.grad = None
+
+    def __repr__(self) -> str:
+        return f"Parameter(data={self.data}, requires_grad={self.requires_grad})"

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -1,0 +1,591 @@
+"""Tests for cakelamp.nn module.
+
+Uses mock objects to test Module, Parameter, Sequential, Linear,
+activation modules, loss functions, and state_dict serialisation.
+"""
+
+from __future__ import annotations
+
+import sys
+import os
+import math
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "python"))
+sys.path.insert(0, os.path.dirname(__file__))
+
+from cakelamp.nn.module import Module
+from cakelamp.nn.parameter import Parameter
+from cakelamp.nn.linear import Linear
+from cakelamp.nn.activations import ReLU, Sigmoid, Tanh, Softmax, LogSoftmax
+from cakelamp.nn.loss import MSELoss, CrossEntropyLoss, NLLLoss
+from cakelamp.nn.containers import Sequential
+from cakelamp.nn.dropout import Dropout
+
+
+# =====================================================================
+# Mock tensors for testing nn module logic
+# =====================================================================
+
+class SimpleTensor:
+    """Minimal mock tensor for testing nn module infrastructure."""
+
+    def __init__(self, data, shape=None):
+        if isinstance(data, list):
+            self._data = data
+        else:
+            self._data = [data]
+        self._shape = shape or [len(self._data)]
+
+    def clone(self):
+        return SimpleTensor(list(self._data), list(self._shape))
+
+    def t(self):
+        """Transpose (for 2D: swap dimensions)."""
+        if len(self._shape) == 2:
+            rows, cols = self._shape
+            new_data = []
+            for j in range(cols):
+                for i in range(rows):
+                    new_data.append(self._data[i * cols + j])
+            return SimpleTensor(new_data, [cols, rows])
+        return self
+
+    def matmul(self, other):
+        """Simple 2D matmul."""
+        assert len(self._shape) == 2 and len(other._shape) == 2
+        m, k = self._shape
+        k2, n = other._shape
+        assert k == k2
+        result = []
+        for i in range(m):
+            for j in range(n):
+                s = 0.0
+                for p in range(k):
+                    s += self._data[i * k + p] * other._data[p * n + j]
+                result.append(s)
+        return SimpleTensor(result, [m, n])
+
+    def add(self, other):
+        if isinstance(other, SimpleTensor):
+            # Broadcasting: if other is 1D and self is 2D, broadcast across rows
+            if len(self._shape) == 2 and len(other._shape) == 1:
+                rows, cols = self._shape
+                result = []
+                for i in range(rows):
+                    for j in range(cols):
+                        result.append(self._data[i * cols + j] + other._data[j])
+                return SimpleTensor(result, [rows, cols])
+            return SimpleTensor([a + b for a, b in zip(self._data, other._data)], list(self._shape))
+        return SimpleTensor([a + other for a in self._data], list(self._shape))
+
+    def sub(self, other):
+        if isinstance(other, SimpleTensor):
+            return SimpleTensor([a - b for a, b in zip(self._data, other._data)], list(self._shape))
+        return SimpleTensor([a - other for a in self._data], list(self._shape))
+
+    def mul(self, other):
+        if isinstance(other, SimpleTensor):
+            return SimpleTensor([a * b for a, b in zip(self._data, other._data)], list(self._shape))
+        return SimpleTensor([a * other for a in self._data], list(self._shape))
+
+    def relu(self):
+        return SimpleTensor([max(0.0, x) for x in self._data], list(self._shape))
+
+    def sigmoid(self):
+        return SimpleTensor([1.0 / (1.0 + math.exp(-x)) for x in self._data], list(self._shape))
+
+    def tanh(self):
+        return SimpleTensor([math.tanh(x) for x in self._data], list(self._shape))
+
+    def softmax(self, dim):
+        # Simple 1D softmax
+        max_val = max(self._data)
+        exps = [math.exp(x - max_val) for x in self._data]
+        s = sum(exps)
+        return SimpleTensor([e / s for e in exps], list(self._shape))
+
+    def log_softmax(self, dim):
+        sm = self.softmax(dim)
+        return SimpleTensor([math.log(x) for x in sm._data], list(self._shape))
+
+    def mean(self):
+        return SimpleTensor([sum(self._data) / len(self._data)])
+
+    def sum(self):
+        return SimpleTensor([sum(self._data)])
+
+    def zero_(self):
+        self._data = [0.0] * len(self._data)
+        return self
+
+    def dropout(self, p, training):
+        if not training:
+            return self
+        return self  # Simplified for testing
+
+    def tolist(self):
+        return list(self._data)
+
+    @property
+    def shape(self):
+        return self._shape
+
+    def __repr__(self):
+        return f"SimpleTensor({self._data})"
+
+
+# =====================================================================
+# Tests: Parameter
+# =====================================================================
+
+class TestParameter:
+    def test_creation(self):
+        t = SimpleTensor([1.0, 2.0, 3.0])
+        p = Parameter(t)
+        assert p.data is t
+        assert p.requires_grad is True
+        assert p.grad is None
+
+    def test_no_grad(self):
+        t = SimpleTensor([1.0])
+        p = Parameter(t, requires_grad=False)
+        assert p.requires_grad is False
+
+    def test_zero_grad(self):
+        p = Parameter(SimpleTensor([1.0]))
+        p.grad = SimpleTensor([0.5])
+        p.zero_grad()
+        assert p.grad is None
+
+    def test_repr(self):
+        p = Parameter(SimpleTensor([1.0]))
+        assert "Parameter" in repr(p)
+
+
+# =====================================================================
+# Tests: Module
+# =====================================================================
+
+class SimpleModule(Module):
+    def __init__(self, in_f, out_f):
+        super().__init__()
+        self.w = Parameter(SimpleTensor([0.5] * (in_f * out_f), [out_f, in_f]))
+        self.in_f = in_f
+        self.out_f = out_f
+
+    def forward(self, x):
+        return x.matmul(self.w.data.t())
+
+
+class TestModule:
+    def test_parameter_registration(self):
+        m = SimpleModule(2, 3)
+        params = list(m.parameters())
+        assert len(params) == 1
+        assert params[0] is m.w
+
+    def test_named_parameters(self):
+        m = SimpleModule(2, 3)
+        named = dict(m.named_parameters())
+        assert "w" in named
+
+    def test_children(self):
+        parent = Module()
+        child1 = SimpleModule(2, 3)
+        child2 = SimpleModule(3, 1)
+        parent._modules["c1"] = child1
+        parent._modules["c2"] = child2
+        children = list(parent.children())
+        assert len(children) == 2
+
+    def test_recursive_parameters(self):
+        parent = Module()
+        parent._modules["child"] = SimpleModule(2, 3)
+        params = list(parent.parameters())
+        assert len(params) == 1
+
+    def test_train_eval(self):
+        m = SimpleModule(2, 3)
+        assert m.training is True
+        m.eval()
+        assert m.training is False
+        m.train()
+        assert m.training is True
+
+    def test_train_propagates_to_children(self):
+        parent = Module()
+        child = SimpleModule(2, 3)
+        parent._modules["child"] = child
+        parent.eval()
+        assert child.training is False
+        parent.train()
+        assert child.training is True
+
+    def test_forward_not_implemented(self):
+        m = Module()
+        with pytest.raises(NotImplementedError):
+            m(SimpleTensor([1.0]))
+
+    def test_call_delegates_to_forward(self):
+        m = SimpleModule(2, 3)
+        x = SimpleTensor([1.0, 2.0], [1, 2])
+        result = m(x)
+        assert len(result._data) == 3
+
+    def test_state_dict(self):
+        m = SimpleModule(2, 3)
+        sd = m.state_dict()
+        assert "w" in sd
+
+    def test_load_state_dict(self):
+        m = SimpleModule(2, 3)
+        new_data = SimpleTensor([9.0] * 6, [3, 2])
+        m.load_state_dict({"w": new_data})
+        assert m.w.data._data == [9.0] * 6
+
+    def test_zero_grad(self):
+        m = SimpleModule(2, 3)
+        m.w.grad = SimpleTensor([1.0] * 6)
+        m.zero_grad()
+        assert m.w.grad is None
+
+    def test_modules_recursive(self):
+        parent = Module()
+        child = SimpleModule(2, 3)
+        parent._modules["child"] = child
+        all_mods = list(parent.modules())
+        assert len(all_mods) == 2
+        assert parent in all_mods
+        assert child in all_mods
+
+    def test_named_modules(self):
+        parent = Module()
+        parent._modules["child"] = SimpleModule(2, 3)
+        named = dict(parent.named_modules())
+        assert "" in named  # parent itself
+        assert "child" in named
+
+    def test_repr(self):
+        m = SimpleModule(2, 3)
+        r = repr(m)
+        assert "SimpleModule" in r
+
+    def test_setattr_auto_registers_parameter(self):
+        m = Module()
+        p = Parameter(SimpleTensor([1.0]))
+        m.p = p
+        assert "p" in m._parameters
+        assert list(m.parameters()) == [p]
+
+    def test_setattr_auto_registers_module(self):
+        m = Module()
+        child = SimpleModule(2, 3)
+        m.child = child
+        assert "child" in m._modules
+        assert list(m.children()) == [child]
+
+
+# =====================================================================
+# Tests: Linear
+# =====================================================================
+
+class TestLinear:
+    def test_creation(self):
+        layer = Linear(10, 5)
+        assert layer.in_features == 10
+        assert layer.out_features == 5
+        assert layer.weight is not None
+        assert layer.bias is not None
+
+    def test_no_bias(self):
+        layer = Linear(10, 5, bias=False)
+        assert layer.bias is None
+
+    def test_parameters_count(self):
+        layer = Linear(10, 5)
+        params = list(layer.parameters())
+        assert len(params) == 2  # weight + bias
+
+    def test_parameters_count_no_bias(self):
+        layer = Linear(10, 5, bias=False)
+        params = list(layer.parameters())
+        assert len(params) == 1  # weight only
+
+    def test_named_parameters(self):
+        layer = Linear(10, 5)
+        named = dict(layer.named_parameters())
+        assert "weight" in named
+        assert "bias" in named
+
+    def test_repr(self):
+        layer = Linear(10, 5)
+        r = repr(layer)
+        assert "in_features=10" in r
+        assert "out_features=5" in r
+        assert "bias=True" in r
+
+    def test_weight_shape(self):
+        layer = Linear(4, 3)
+        # Weight should have out_features * in_features elements
+        assert len(layer.weight.data) == 12  # 3*4
+
+    def test_state_dict(self):
+        layer = Linear(4, 3)
+        sd = layer.state_dict()
+        assert "weight" in sd
+        assert "bias" in sd
+
+
+# =====================================================================
+# Tests: Activations
+# =====================================================================
+
+class TestActivations:
+    def test_relu(self):
+        act = ReLU()
+        x = SimpleTensor([-1.0, 0.0, 1.0, 2.0])
+        result = act(x)
+        assert result.tolist() == [0.0, 0.0, 1.0, 2.0]
+
+    def test_sigmoid(self):
+        act = Sigmoid()
+        x = SimpleTensor([0.0])
+        result = act(x)
+        assert abs(result.tolist()[0] - 0.5) < 1e-6
+
+    def test_sigmoid_large(self):
+        act = Sigmoid()
+        x = SimpleTensor([10.0])
+        result = act(x)
+        assert result.tolist()[0] > 0.99
+
+    def test_tanh(self):
+        act = Tanh()
+        x = SimpleTensor([0.0])
+        result = act(x)
+        assert abs(result.tolist()[0]) < 1e-6
+
+    def test_softmax(self):
+        act = Softmax(dim=-1)
+        x = SimpleTensor([1.0, 2.0, 3.0])
+        result = act(x)
+        # Should sum to 1
+        assert abs(sum(result.tolist()) - 1.0) < 1e-6
+        # Should be monotonically increasing
+        vals = result.tolist()
+        assert vals[0] < vals[1] < vals[2]
+
+    def test_log_softmax(self):
+        act = LogSoftmax(dim=-1)
+        x = SimpleTensor([1.0, 2.0, 3.0])
+        result = act(x)
+        # All values should be negative
+        assert all(v < 0 for v in result.tolist())
+        # exp should sum to ~1
+        assert abs(sum(math.exp(v) for v in result.tolist()) - 1.0) < 1e-6
+
+    def test_relu_training_mode(self):
+        act = ReLU()
+        assert act.training is True
+        act.eval()
+        # ReLU behaves the same in eval
+        x = SimpleTensor([-1.0, 1.0])
+        result = act(x)
+        assert result.tolist() == [0.0, 1.0]
+
+
+# =====================================================================
+# Tests: Loss functions
+# =====================================================================
+
+class TestLoss:
+    def test_mse_loss_mean(self):
+        loss_fn = MSELoss(reduction="mean")
+        pred = SimpleTensor([1.0, 2.0, 3.0])
+        target = SimpleTensor([1.5, 2.5, 3.5])
+        loss = loss_fn(pred, target)
+        # mean((0.5^2, 0.5^2, 0.5^2)) = 0.25
+        assert abs(loss._data[0] - 0.25) < 1e-6
+
+    def test_mse_loss_sum(self):
+        loss_fn = MSELoss(reduction="sum")
+        pred = SimpleTensor([1.0, 2.0, 3.0])
+        target = SimpleTensor([1.5, 2.5, 3.5])
+        loss = loss_fn(pred, target)
+        # sum(0.25, 0.25, 0.25) = 0.75
+        assert abs(loss._data[0] - 0.75) < 1e-6
+
+    def test_mse_loss_none(self):
+        loss_fn = MSELoss(reduction="none")
+        pred = SimpleTensor([1.0, 2.0])
+        target = SimpleTensor([2.0, 2.0])
+        loss = loss_fn(pred, target)
+        assert len(loss._data) == 2
+        assert abs(loss._data[0] - 1.0) < 1e-6
+        assert abs(loss._data[1] - 0.0) < 1e-6
+
+    def test_mse_loss_zero(self):
+        loss_fn = MSELoss()
+        pred = SimpleTensor([1.0, 2.0])
+        target = SimpleTensor([1.0, 2.0])
+        loss = loss_fn(pred, target)
+        assert abs(loss._data[0]) < 1e-6
+
+    def test_mse_invalid_reduction(self):
+        with pytest.raises(ValueError, match="Invalid reduction"):
+            MSELoss(reduction="invalid")
+
+    def test_mse_repr(self):
+        loss_fn = MSELoss()
+        assert "mean" in repr(loss_fn)
+
+    def test_cross_entropy_invalid_reduction(self):
+        with pytest.raises(ValueError, match="Invalid reduction"):
+            CrossEntropyLoss(reduction="bad")
+
+    def test_nll_invalid_reduction(self):
+        with pytest.raises(ValueError, match="Invalid reduction"):
+            NLLLoss(reduction="bad")
+
+
+# =====================================================================
+# Tests: Sequential
+# =====================================================================
+
+class TestSequential:
+    def test_forward(self):
+        seq = Sequential(ReLU())
+        x = SimpleTensor([-1.0, 0.0, 1.0])
+        result = seq(x)
+        assert result.tolist() == [0.0, 0.0, 1.0]
+
+    def test_multiple_layers(self):
+        seq = Sequential(ReLU(), ReLU())
+        x = SimpleTensor([-1.0, 1.0])
+        result = seq(x)
+        assert result.tolist() == [0.0, 1.0]
+
+    def test_len(self):
+        seq = Sequential(ReLU(), Sigmoid(), Tanh())
+        assert len(seq) == 3
+
+    def test_getitem(self):
+        relu = ReLU()
+        sigmoid = Sigmoid()
+        seq = Sequential(relu, sigmoid)
+        assert seq[0] is relu
+        assert seq[1] is sigmoid
+        assert seq[-1] is sigmoid
+
+    def test_iter(self):
+        relu = ReLU()
+        sigmoid = Sigmoid()
+        seq = Sequential(relu, sigmoid)
+        modules = list(seq)
+        assert modules[0] is relu
+        assert modules[1] is sigmoid
+
+    def test_append(self):
+        seq = Sequential(ReLU())
+        seq.append(Sigmoid())
+        assert len(seq) == 2
+
+    def test_parameters(self):
+        # Sequential with Linear layers
+        l1 = Linear(2, 3)
+        l2 = Linear(3, 1)
+        seq = Sequential(l1, ReLU(), l2)
+        params = list(seq.parameters())
+        # l1 has weight+bias, l2 has weight+bias = 4
+        assert len(params) == 4
+
+    def test_train_eval(self):
+        seq = Sequential(ReLU(), Dropout(0.5))
+        seq.eval()
+        assert not seq.training
+        for m in seq:
+            assert not m.training
+        seq.train()
+        assert seq.training
+
+    def test_state_dict(self):
+        l = Linear(2, 3)
+        seq = Sequential(l, ReLU())
+        sd = seq.state_dict()
+        assert "0.weight" in sd
+        assert "0.bias" in sd
+
+    def test_repr(self):
+        seq = Sequential(ReLU(), Sigmoid())
+        r = repr(seq)
+        assert "Sequential" in r
+        assert "ReLU" in r
+        assert "Sigmoid" in r
+
+    def test_from_ordered_dict(self):
+        from collections import OrderedDict
+        seq = Sequential(OrderedDict([
+            ("relu", ReLU()),
+            ("sigmoid", Sigmoid()),
+        ]))
+        assert len(seq) == 2
+        sd = seq.state_dict()
+        # No parameters in activations, but module should still work
+        x = SimpleTensor([-1.0, 1.0])
+        result = seq(x)
+
+
+# =====================================================================
+# Tests: Dropout
+# =====================================================================
+
+class TestDropout:
+    def test_creation(self):
+        d = Dropout(0.5)
+        assert d.p == 0.5
+
+    def test_invalid_p(self):
+        with pytest.raises(ValueError):
+            Dropout(1.0)
+        with pytest.raises(ValueError):
+            Dropout(-0.1)
+
+    def test_eval_mode_passthrough(self):
+        d = Dropout(0.5)
+        d.eval()
+        x = SimpleTensor([1.0, 2.0, 3.0])
+        result = d(x)
+        assert result.tolist() == [1.0, 2.0, 3.0]
+
+    def test_repr(self):
+        d = Dropout(0.3)
+        assert "0.3" in repr(d)
+
+
+# =====================================================================
+# Tests: Nested module state_dict
+# =====================================================================
+
+class TestNestedStateDict:
+    def test_nested_state_dict(self):
+        """Test state_dict with nested modules."""
+        model = Sequential(
+            Linear(4, 3),
+            ReLU(),
+            Linear(3, 2),
+        )
+        sd = model.state_dict()
+        assert "0.weight" in sd
+        assert "0.bias" in sd
+        assert "2.weight" in sd
+        assert "2.bias" in sd
+
+    def test_load_nested_state_dict(self):
+        """Test loading state_dict into nested modules."""
+        model = Sequential(Linear(2, 2), Linear(2, 1))
+        sd = model.state_dict()
+        # Modify weights
+        sd["0.weight"] = SimpleTensor([9.0, 9.0, 9.0, 9.0], [2, 2])
+        model.load_state_dict(sd)
+        assert model[0].weight.data._data == [9.0, 9.0, 9.0, 9.0]


### PR DESCRIPTION
## Summary
- Implements `cakelamp.nn` module mirroring `torch.nn` API
- `Module` base class with auto parameter/module registration, recursive traversal, state_dict, train/eval modes
- `Parameter` class for trainable parameters
- `Linear` layer with Kaiming uniform initialization
- Activation functions: `ReLU`, `Sigmoid`, `Tanh`, `Softmax`, `LogSoftmax`
- Loss functions: `MSELoss`, `CrossEntropyLoss`, `NLLLoss` (with reduction modes)
- `Sequential` container (positional args or OrderedDict)
- `Dropout` module (training/eval mode aware)
- 60 comprehensive tests with mock tensors (all passing, pytest: 0.07s)

## Test plan
- [x] All 60 nn module tests pass
- [x] Module auto-registration of Parameters and sub-Modules tested
- [x] Recursive parameter discovery and state_dict tested
- [x] All activations verified with numerical checks
- [x] MSELoss verified with all reduction modes
- [x] Sequential forward, indexing, iteration tested
- [x] Nested state_dict save/load tested

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)