### PR TITLE
Add MNIST data loader and training script

### DIFF
--- a/examples/train_mnist.py
+++ b/examples/train_mnist.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""MNIST end-to-end training with CakeLamp.
+
+Trains a 2-layer MLP (784 -> 128 -> 10) on MNIST to achieve >= 95% accuracy.
+Architecture: Linear(784,128) -> ReLU -> Linear(128,10) -> CrossEntropyLoss
+Optimizer: SGD with momentum.
+
+Usage:
+    python examples/train_mnist.py [--epochs N] [--batch-size N] [--lr FLOAT]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+
+from cakelamp.data.mnist import load_mnist
+from cakelamp.tensor import Tensor
+from cakelamp.nn import Module, Linear, ReLU, Sequential, CrossEntropyLoss
+from cakelamp.optim import SGD
+
+
+class MLP(Module):
+    """Simple 2-layer MLP for MNIST classification.
+
+    Architecture: Linear(784, 128) -> ReLU -> Linear(128, 10)
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc1 = Linear(784, 128)
+        self.relu = ReLU()
+        self.fc2 = Linear(128, 10)
+
+    def forward(self, x):
+        x = self.fc1(x)
+        x = self.relu(x)
+        x = self.fc2(x)
+        return x
+
+
+def make_batch_tensor(batch_images, batch_labels):
+    """Convert a batch of images and labels to Tensors.
+
+    Parameters
+    ----------
+    batch_images : list[list[float]]
+        Batch of flattened images, each of length 784.
+    batch_labels : list[int]
+        Batch of integer labels 0-9.
+
+    Returns
+    -------
+    tuple[Tensor, Tensor]
+        (images_tensor, labels_tensor)
+    """
+    batch_size = len(batch_images)
+    # Flatten all images into one big list for the tensor
+    flat_data = []
+    for img in batch_images:
+        flat_data.extend(img)
+    images = Tensor(flat_data, requires_grad=False,
+                    _shape=[batch_size, 784])
+    labels = Tensor([float(l) for l in batch_labels],
+                    _shape=[batch_size])
+    return images, labels
+
+
+def compute_accuracy(model, dataset, batch_size=256):
+    """Compute accuracy on a dataset.
+
+    Parameters
+    ----------
+    model : Module
+        The model to evaluate.
+    dataset : MNISTDataset
+        The dataset to evaluate on.
+    batch_size : int
+        Batch size for evaluation.
+
+    Returns
+    -------
+    float
+        Accuracy in [0, 1].
+    """
+    model.eval()
+    correct = 0
+    total = 0
+
+    for batch_images, batch_labels in dataset.batches(batch_size, shuffle=False):
+        images, labels = make_batch_tensor(batch_images, batch_labels)
+        logits = model(images)
+
+        # Argmax to get predictions
+        preds = logits.argmax(dim=1)
+        for i in range(len(batch_labels)):
+            pred_class = int(preds._contiguous_data()[i])
+            if pred_class == batch_labels[i]:
+                correct += 1
+            total += 1
+
+    model.train()
+    return correct / total if total > 0 else 0.0
+
+
+def train(
+    epochs: int = 10,
+    batch_size: int = 64,
+    lr: float = 0.01,
+    momentum: float = 0.9,
+    data_dir: str = "./data/mnist",
+    log_interval: int = 100,
+) -> float:
+    """Train the MNIST MLP.
+
+    Parameters
+    ----------
+    epochs : int
+        Number of training epochs.
+    batch_size : int
+        Mini-batch size.
+    lr : float
+        Learning rate.
+    momentum : float
+        SGD momentum.
+    data_dir : str
+        Directory for MNIST data.
+    log_interval : int
+        Print loss every N batches.
+
+    Returns
+    -------
+    float
+        Final test accuracy.
+    """
+    # Load data
+    train_data, test_data = load_mnist(data_dir=data_dir)
+
+    # Create model, loss, optimizer
+    model = MLP()
+    criterion = CrossEntropyLoss()
+    optimizer = SGD(model.parameters(), lr=lr, momentum=momentum)
+
+    print(f"\nTraining MLP: 784 -> 128 -> 10")
+    print(f"Epochs: {epochs}, Batch size: {batch_size}, LR: {lr}, Momentum: {momentum}")
+    print(f"Parameters: {sum(1 for _ in model.parameters())}")
+    print()
+
+    for epoch in range(1, epochs + 1):
+        epoch_start = time.time()
+        running_loss = 0.0
+        batch_count = 0
+
+        for batch_images, batch_labels in train_data.batches(batch_size, shuffle=True):
+            images, labels = make_batch_tensor(batch_images, batch_labels)
+
+            # Forward pass
+            optimizer.zero_grad()
+            logits = model(images)
+            loss = criterion(logits, labels)
+
+            # Backward pass
+            loss.backward()
+
+            # Update weights
+            optimizer.step()
+
+            running_loss += loss.item()
+            batch_count += 1
+
+            if batch_count % log_interval == 0:
+                avg_loss = running_loss / batch_count
+                print(f"  Epoch {epoch}, Batch {batch_count}: loss = {avg_loss:.4f}")
+
+        epoch_time = time.time() - epoch_start
+        avg_loss = running_loss / batch_count if batch_count > 0 else 0
+
+        # Evaluate on test set
+        test_acc = compute_accuracy(model, test_data)
+        print(
+            f"Epoch {epoch}/{epochs}: "
+            f"loss = {avg_loss:.4f}, "
+            f"test_acc = {test_acc:.4f} ({test_acc*100:.1f}%), "
+            f"time = {epoch_time:.1f}s"
+        )
+
+        if test_acc >= 0.95:
+            print(f"\n** Target accuracy (95%) reached at epoch {epoch}! **")
+            return test_acc
+
+    final_acc = compute_accuracy(model, test_data)
+    print(f"\nFinal test accuracy: {final_acc:.4f} ({final_acc*100:.1f}%)")
+    if final_acc < 0.95:
+        print("WARNING: Did not reach 95% target accuracy.")
+    return final_acc
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Train MNIST MLP with CakeLamp")
+    parser.add_argument("--epochs", type=int, default=10, help="Number of epochs")
+    parser.add_argument("--batch-size", type=int, default=64, help="Batch size")
+    parser.add_argument("--lr", type=float, default=0.01, help="Learning rate")
+    parser.add_argument("--momentum", type=float, default=0.9, help="SGD momentum")
+    parser.add_argument("--data-dir", type=str, default="./data/mnist", help="MNIST data dir")
+    args = parser.parse_args()
+
+    accuracy = train(
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        lr=args.lr,
+        momentum=args.momentum,
+        data_dir=args.data_dir,
+    )
+
+    sys.exit(0 if accuracy >= 0.95 else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/cakelamp/data/__init__.py
+++ b/python/cakelamp/data/__init__.py
@@ -1,0 +1,5 @@
+"""CakeLamp data loading utilities."""
+
+from cakelamp.data.mnist import load_mnist, MNISTDataset
+
+__all__ = ["load_mnist", "MNISTDataset"]

--- a/python/cakelamp/data/mnist.py
+++ b/python/cakelamp/data/mnist.py
@@ -1,0 +1,179 @@
+"""MNIST dataset loader.
+
+Pure Python parsing of the IDX file format. Downloads MNIST data
+from the web if not already cached locally.
+
+IDX file format:
+  - 4 bytes: magic number (big-endian)
+  - 4 bytes: number of items (big-endian)
+  - For images: 4 bytes rows, 4 bytes cols, then row*col bytes per image
+  - For labels: 1 byte per label
+"""
+
+from __future__ import annotations
+
+import gzip
+import os
+import struct
+import urllib.request
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+
+# MNIST mirror URLs
+_MNIST_URLS = {
+    "train-images": "https://ossci-datasets.s3.amazonaws.com/mnist/train-images-idx3-ubyte.gz",
+    "train-labels": "https://ossci-datasets.s3.amazonaws.com/mnist/train-labels-idx1-ubyte.gz",
+    "test-images": "https://ossci-datasets.s3.amazonaws.com/mnist/t10k-images-idx3-ubyte.gz",
+    "test-labels": "https://ossci-datasets.s3.amazonaws.com/mnist/t10k-labels-idx1-ubyte.gz",
+}
+
+
+def _download_file(url: str, dest: Path) -> None:
+    """Download a file if it doesn't exist."""
+    if dest.exists():
+        return
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    print(f"Downloading {url} ...")
+    urllib.request.urlretrieve(url, str(dest))
+    print(f"  -> saved to {dest}")
+
+
+def _read_idx_images(path: Path) -> Tuple[List[List[float]], int, int, int]:
+    """Read IDX image file and return (flat_images, n, rows, cols).
+
+    Each image is a flat list of float32 values normalised to [0, 1].
+    """
+    with gzip.open(str(path), "rb") as f:
+        magic = struct.unpack(">I", f.read(4))[0]
+        if magic != 2051:
+            raise ValueError(f"Invalid magic number for images: {magic}")
+        n = struct.unpack(">I", f.read(4))[0]
+        rows = struct.unpack(">I", f.read(4))[0]
+        cols = struct.unpack(">I", f.read(4))[0]
+
+        images = []
+        pixel_count = rows * cols
+        for _ in range(n):
+            raw = f.read(pixel_count)
+            if len(raw) != pixel_count:
+                raise ValueError("Unexpected EOF while reading images")
+            # Normalise to [0, 1]
+            img = [b / 255.0 for b in raw]
+            images.append(img)
+
+    return images, n, rows, cols
+
+
+def _read_idx_labels(path: Path) -> List[int]:
+    """Read IDX label file and return list of integer labels."""
+    with gzip.open(str(path), "rb") as f:
+        magic = struct.unpack(">I", f.read(4))[0]
+        if magic != 2049:
+            raise ValueError(f"Invalid magic number for labels: {magic}")
+        n = struct.unpack(">I", f.read(4))[0]
+
+        raw = f.read(n)
+        if len(raw) != n:
+            raise ValueError("Unexpected EOF while reading labels")
+        labels = list(raw)
+
+    return labels
+
+
+class MNISTDataset:
+    """MNIST dataset with batching support.
+
+    Parameters
+    ----------
+    images : list[list[float]]
+        Each image is a flat list of 784 floats in [0, 1].
+    labels : list[int]
+        Integer labels 0-9.
+    """
+
+    def __init__(self, images: List[List[float]], labels: List[int]) -> None:
+        assert len(images) == len(labels)
+        self.images = images
+        self.labels = labels
+
+    def __len__(self) -> int:
+        return len(self.images)
+
+    def batches(self, batch_size: int, shuffle: bool = True):
+        """Yield (batch_images, batch_labels) tuples.
+
+        Parameters
+        ----------
+        batch_size : int
+            Number of samples per batch.
+        shuffle : bool
+            Whether to shuffle the dataset each epoch.
+
+        Yields
+        ------
+        tuple[list[list[float]], list[int]]
+            Batch of images (flat lists) and labels.
+        """
+        import random
+
+        indices = list(range(len(self.images)))
+        if shuffle:
+            random.shuffle(indices)
+
+        for start in range(0, len(indices), batch_size):
+            batch_idx = indices[start : start + batch_size]
+            batch_images = [self.images[i] for i in batch_idx]
+            batch_labels = [self.labels[i] for i in batch_idx]
+            yield batch_images, batch_labels
+
+
+def load_mnist(
+    data_dir: Optional[str] = None,
+    download: bool = True,
+) -> Tuple[MNISTDataset, MNISTDataset]:
+    """Load the MNIST dataset.
+
+    Parameters
+    ----------
+    data_dir : str, optional
+        Directory to store/load data. Defaults to ``./data/mnist``.
+    download : bool
+        Whether to download data if not present (default: True).
+
+    Returns
+    -------
+    tuple[MNISTDataset, MNISTDataset]
+        (train_dataset, test_dataset)
+    """
+    if data_dir is None:
+        data_dir = os.path.join(".", "data", "mnist")
+    data_path = Path(data_dir)
+
+    # File paths
+    files = {
+        "train-images": data_path / "train-images-idx3-ubyte.gz",
+        "train-labels": data_path / "train-labels-idx1-ubyte.gz",
+        "test-images": data_path / "t10k-images-idx3-ubyte.gz",
+        "test-labels": data_path / "t10k-labels-idx1-ubyte.gz",
+    }
+
+    if download:
+        for key, path in files.items():
+            _download_file(_MNIST_URLS[key], path)
+
+    # Parse IDX files
+    train_images, n_train, rows, cols = _read_idx_images(files["train-images"])
+    train_labels = _read_idx_labels(files["train-labels"])
+    test_images, n_test, _, _ = _read_idx_images(files["test-images"])
+    test_labels = _read_idx_labels(files["test-labels"])
+
+    assert n_train == len(train_labels), "Train image/label count mismatch"
+    assert n_test == len(test_labels), "Test image/label count mismatch"
+    assert rows == 28 and cols == 28, f"Unexpected image size: {rows}x{cols}"
+
+    train_dataset = MNISTDataset(train_images, train_labels)
+    test_dataset = MNISTDataset(test_images, test_labels)
+
+    print(f"MNIST loaded: {n_train} train, {n_test} test ({rows}x{cols})")
+    return train_dataset, test_dataset

--- a/tests/test_mnist_data.py
+++ b/tests/test_mnist_data.py
@@ -1,0 +1,252 @@
+"""Tests for MNIST data loading utilities.
+
+Tests the IDX file parser and dataset batching without downloading
+actual MNIST data. Uses synthetic IDX files.
+"""
+
+from __future__ import annotations
+
+import gzip
+import os
+import struct
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "python"))
+
+from cakelamp.data.mnist import (
+    MNISTDataset,
+    _read_idx_images,
+    _read_idx_labels,
+)
+from pathlib import Path
+
+
+def _make_idx_images(path: Path, images: list, rows: int = 2, cols: int = 2) -> None:
+    """Write a synthetic IDX images file (gzipped).
+
+    Parameters
+    ----------
+    path : Path
+        Output .gz file path.
+    images : list[list[int]]
+        List of images, each a flat list of pixel values (0-255).
+    rows, cols : int
+        Image dimensions.
+    """
+    n = len(images)
+    with gzip.open(str(path), "wb") as f:
+        f.write(struct.pack(">I", 2051))  # magic
+        f.write(struct.pack(">I", n))
+        f.write(struct.pack(">I", rows))
+        f.write(struct.pack(">I", cols))
+        for img in images:
+            f.write(bytes(img))
+
+
+def _make_idx_labels(path: Path, labels: list) -> None:
+    """Write a synthetic IDX labels file (gzipped)."""
+    n = len(labels)
+    with gzip.open(str(path), "wb") as f:
+        f.write(struct.pack(">I", 2049))  # magic
+        f.write(struct.pack(">I", n))
+        f.write(bytes(labels))
+
+
+# =====================================================================
+# IDX parser tests
+# =====================================================================
+
+class TestIDXParser:
+    def test_read_images(self, tmp_path):
+        """Read a synthetic 2x2 image file."""
+        img1 = [0, 128, 255, 64]
+        img2 = [255, 0, 128, 32]
+        path = tmp_path / "images.gz"
+        _make_idx_images(path, [img1, img2], rows=2, cols=2)
+
+        images, n, rows, cols = _read_idx_images(path)
+        assert n == 2
+        assert rows == 2
+        assert cols == 2
+        assert len(images) == 2
+        assert len(images[0]) == 4
+        # Check normalisation to [0, 1]
+        assert images[0][0] == 0.0 / 255.0
+        assert abs(images[0][1] - 128.0 / 255.0) < 1e-6
+        assert images[0][2] == 1.0  # 255/255
+
+    def test_read_labels(self, tmp_path):
+        """Read a synthetic labels file."""
+        labels = [0, 5, 9, 3]
+        path = tmp_path / "labels.gz"
+        _make_idx_labels(path, labels)
+
+        result = _read_idx_labels(path)
+        assert result == [0, 5, 9, 3]
+
+    def test_invalid_image_magic(self, tmp_path):
+        """Wrong magic number should raise."""
+        path = tmp_path / "bad_images.gz"
+        with gzip.open(str(path), "wb") as f:
+            f.write(struct.pack(">I", 9999))
+            f.write(struct.pack(">I", 0))
+            f.write(struct.pack(">I", 1))
+            f.write(struct.pack(">I", 1))
+        with pytest.raises(ValueError, match="Invalid magic"):
+            _read_idx_images(path)
+
+    def test_invalid_label_magic(self, tmp_path):
+        """Wrong magic number should raise."""
+        path = tmp_path / "bad_labels.gz"
+        with gzip.open(str(path), "wb") as f:
+            f.write(struct.pack(">I", 9999))
+            f.write(struct.pack(">I", 0))
+        with pytest.raises(ValueError, match="Invalid magic"):
+            _read_idx_labels(path)
+
+    def test_single_image(self, tmp_path):
+        """Single image file."""
+        img = [100, 200]
+        path = tmp_path / "single.gz"
+        _make_idx_images(path, [img], rows=1, cols=2)
+
+        images, n, rows, cols = _read_idx_images(path)
+        assert n == 1
+        assert rows == 1
+        assert cols == 2
+        assert abs(images[0][0] - 100 / 255.0) < 1e-6
+
+    def test_larger_images(self, tmp_path):
+        """28x28 images (real MNIST size)."""
+        import random
+        random.seed(42)
+        n_imgs = 5
+        size = 28 * 28
+        imgs = [[random.randint(0, 255) for _ in range(size)] for _ in range(n_imgs)]
+
+        path = tmp_path / "large.gz"
+        _make_idx_images(path, imgs, rows=28, cols=28)
+
+        images, n, rows, cols = _read_idx_images(path)
+        assert n == 5
+        assert rows == 28
+        assert cols == 28
+        assert len(images[0]) == 784
+        # All values in [0, 1]
+        for img in images:
+            assert all(0.0 <= v <= 1.0 for v in img)
+
+
+# =====================================================================
+# MNISTDataset tests
+# =====================================================================
+
+class TestMNISTDataset:
+    def test_len(self):
+        images = [[0.0] * 4 for _ in range(10)]
+        labels = list(range(10))
+        ds = MNISTDataset(images, labels)
+        assert len(ds) == 10
+
+    def test_batches_no_shuffle(self):
+        images = [[float(i)] * 4 for i in range(10)]
+        labels = list(range(10))
+        ds = MNISTDataset(images, labels)
+
+        batches = list(ds.batches(batch_size=3, shuffle=False))
+        assert len(batches) == 4  # 3+3+3+1
+        assert len(batches[0][0]) == 3
+        assert len(batches[0][1]) == 3
+        assert len(batches[-1][0]) == 1  # last batch has 1 item
+
+    def test_batches_cover_all_data(self):
+        n = 20
+        images = [[0.0] * 4 for _ in range(n)]
+        labels = list(range(n))
+        ds = MNISTDataset(images, labels)
+
+        all_labels = []
+        for _, batch_labels in ds.batches(batch_size=7, shuffle=False):
+            all_labels.extend(batch_labels)
+        assert sorted(all_labels) == list(range(n))
+
+    def test_batches_shuffle(self):
+        """Shuffled batches should still cover all data."""
+        import random
+        random.seed(42)
+        n = 50
+        images = [[float(i)] * 4 for i in range(n)]
+        labels = list(range(n))
+        ds = MNISTDataset(images, labels)
+
+        all_labels = []
+        for _, batch_labels in ds.batches(batch_size=10, shuffle=True):
+            all_labels.extend(batch_labels)
+        assert sorted(all_labels) == list(range(n))
+
+    def test_exact_batch_size(self):
+        """When dataset size is divisible by batch size."""
+        images = [[0.0] * 4 for _ in range(12)]
+        labels = list(range(12))
+        ds = MNISTDataset(images, labels)
+
+        batches = list(ds.batches(batch_size=4, shuffle=False))
+        assert len(batches) == 3
+        assert all(len(b[0]) == 4 for b in batches)
+
+    def test_single_batch(self):
+        """Batch size larger than dataset."""
+        images = [[0.0] * 4 for _ in range(5)]
+        labels = list(range(5))
+        ds = MNISTDataset(images, labels)
+
+        batches = list(ds.batches(batch_size=100, shuffle=False))
+        assert len(batches) == 1
+        assert len(batches[0][0]) == 5
+
+
+# =====================================================================
+# Integration test (synthetic data, no download)
+# =====================================================================
+
+class TestIntegration:
+    def test_end_to_end_data_flow(self, tmp_path):
+        """Parse IDX files -> MNISTDataset -> iterate batches."""
+        import random
+        random.seed(0)
+
+        # Create synthetic 4x4 images
+        n_train = 20
+        rows, cols = 4, 4
+        imgs = [[random.randint(0, 255) for _ in range(rows * cols)]
+                for _ in range(n_train)]
+        labels = [random.randint(0, 9) for _ in range(n_train)]
+
+        img_path = tmp_path / "images.gz"
+        lbl_path = tmp_path / "labels.gz"
+        _make_idx_images(img_path, imgs, rows=rows, cols=cols)
+        _make_idx_labels(lbl_path, labels)
+
+        # Parse
+        parsed_imgs, n, r, c = _read_idx_images(img_path)
+        parsed_lbls = _read_idx_labels(lbl_path)
+        assert n == n_train
+        assert r == rows
+        assert c == cols
+
+        # Create dataset
+        ds = MNISTDataset(parsed_imgs, parsed_lbls)
+        assert len(ds) == n_train
+
+        # Iterate batches
+        total = 0
+        for batch_imgs, batch_lbls in ds.batches(batch_size=7, shuffle=False):
+            total += len(batch_imgs)
+            assert len(batch_imgs) == len(batch_lbls)
+            for img in batch_imgs:
+                assert len(img) == rows * cols
+                assert all(0.0 <= v <= 1.0 for v in img)
+        assert total == n_train


### PR DESCRIPTION
## Summary
- Implements MNIST IDX file format parser with gzip support
- `MNISTDataset` class with batching and shuffling
- Auto-download from OSSCI S3 mirror
- `examples/train_mnist.py`: 2-layer MLP (784→128→10) training script targeting ≥95% accuracy
- Uses SGD with momentum, CrossEntropyLoss
- 13 comprehensive tests for data loading (all passing, pytest: 0.09s)

Note: The training script depends on the autograd layer (issue #3) to be merged. The data loading infrastructure is fully functional and tested independently.

## Test plan
- [x] All 13 MNIST data loader tests pass
- [x] IDX image/label parser verified with synthetic data
- [x] Batch iteration covers all data (shuffled and unshuffled)
- [x] Edge cases: single image, large images, invalid magic numbers
- [ ] Full training (pending autograd merge)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)