### PR TITLE
Add autograd (reverse-mode AD) with 20 tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,6 @@ description = "A lightweight tensor library with Rust backend"
 requires-python = ">=3.9"
 dependencies = []
 
-[dependency-groups]
-dev = ["pytest>=7.0", "maturin>=1.0"]
-
 [tool.maturin]
 manifest-path = "crates/cakelamp-core/Cargo.toml"
 features = ["pyo3"]

--- a/python/cakelamp/autograd/__init__.py
+++ b/python/cakelamp/autograd/__init__.py
@@ -1,0 +1,12 @@
+"""CakeLamp Autograd: Reverse-mode automatic differentiation.
+
+The computation graph is built in Python (like PyTorch). Each differentiable
+op creates a Function (Node) in the graph that stores references to input
+tensors and edges to parent nodes. Tensor.backward() does topological sort
++ reverse traversal.
+"""
+
+from cakelamp.autograd.tensor import AutogradTensor
+from cakelamp.autograd.function import Function
+
+__all__ = ["AutogradTensor", "Function"]

--- a/python/cakelamp/autograd/function.py
+++ b/python/cakelamp/autograd/function.py
@@ -1,0 +1,309 @@
+"""Autograd Function (Node) base class and built-in backward functions.
+
+Each differentiable operation creates a Function node in the computation
+graph. The node stores:
+  - saved_tensors: input tensors needed for backward computation
+  - inputs: direct references to input AutogradTensors (for graph traversal)
+
+During backward(), we do topological sort + reverse traversal.
+"""
+
+from __future__ import annotations
+from typing import TYPE_CHECKING, Tuple, Optional, List
+
+if TYPE_CHECKING:
+    from cakelamp.autograd.tensor import AutogradTensor
+
+
+class Function:
+    """Base class for autograd functions (computation graph nodes)."""
+
+    def __init__(self):
+        self.saved_tensors: List[AutogradTensor] = []
+        self.inputs: List[AutogradTensor] = []
+
+    def save_for_backward(self, *tensors: AutogradTensor):
+        """Save tensors for use in backward()."""
+        self.saved_tensors = list(tensors)
+
+    def backward(self, grad_output: AutogradTensor) -> Tuple[Optional[AutogradTensor], ...]:
+        """Compute gradients. Must be overridden by subclasses."""
+        raise NotImplementedError
+
+
+# ── Built-in Functions ────────────────────────────────────────────────
+
+
+class AddBackward(Function):
+    """Backward for a + b."""
+
+    def backward(self, grad_output):
+        a, b = self.saved_tensors
+        grad_a = _unbroadcast(grad_output, a.shape)
+        grad_b = _unbroadcast(grad_output, b.shape)
+        return grad_a, grad_b
+
+
+class SubBackward(Function):
+    """Backward for a - b."""
+
+    def backward(self, grad_output):
+        a, b = self.saved_tensors
+        grad_a = _unbroadcast(grad_output, a.shape)
+        grad_b = _unbroadcast(-grad_output, b.shape)
+        return grad_a, grad_b
+
+
+class MulBackward(Function):
+    """Backward for a * b (element-wise)."""
+
+    def backward(self, grad_output):
+        a, b = self.saved_tensors
+        grad_a = _unbroadcast(grad_output * b, a.shape)
+        grad_b = _unbroadcast(grad_output * a, b.shape)
+        return grad_a, grad_b
+
+
+class DivBackward(Function):
+    """Backward for a / b."""
+
+    def backward(self, grad_output):
+        a, b = self.saved_tensors
+        grad_a = _unbroadcast(grad_output / b, a.shape)
+        grad_b = _unbroadcast(grad_output * (-a / (b * b)), b.shape)
+        return grad_a, grad_b
+
+
+class NegBackward(Function):
+    """Backward for -a."""
+
+    def backward(self, grad_output):
+        return (-grad_output,)
+
+
+class MatmulBackward(Function):
+    """Backward for a @ b (2D matrix multiply)."""
+
+    def backward(self, grad_output):
+        a, b = self.saved_tensors
+        grad_a = grad_output.matmul(b.t())
+        grad_b = a.t().matmul(grad_output)
+        return grad_a, grad_b
+
+
+class ExpBackward(Function):
+    """Backward for exp(a)."""
+
+    def __init__(self):
+        super().__init__()
+        self.result = None
+
+    def backward(self, grad_output):
+        return (grad_output * self.result,)
+
+
+class LogBackward(Function):
+    """Backward for log(a)."""
+
+    def backward(self, grad_output):
+        (a,) = self.saved_tensors
+        return (grad_output / a,)
+
+
+class ReluBackward(Function):
+    """Backward for relu(a)."""
+
+    def backward(self, grad_output):
+        (a,) = self.saved_tensors
+        from cakelamp.autograd.tensor import AutogradTensor
+        import cakelamp._core as _core
+        zero = AutogradTensor(_core.zeros(list(a.shape)), requires_grad=False)
+        mask = AutogradTensor(a.data.gt(zero.data), requires_grad=False)
+        return (grad_output * mask,)
+
+
+class SigmoidBackward(Function):
+    """Backward for sigmoid(a). dsigmoid/dx = sigmoid(x) * (1 - sigmoid(x))"""
+
+    def __init__(self):
+        super().__init__()
+        self.result = None
+
+    def backward(self, grad_output):
+        from cakelamp.autograd.tensor import AutogradTensor
+        import cakelamp._core as _core
+        ones = AutogradTensor(_core.ones(list(self.result.shape)), requires_grad=False)
+        return (grad_output * self.result * (ones - self.result),)
+
+
+class TanhBackward(Function):
+    """Backward for tanh(a). dtanh/dx = 1 - tanh(x)^2"""
+
+    def __init__(self):
+        super().__init__()
+        self.result = None
+
+    def backward(self, grad_output):
+        from cakelamp.autograd.tensor import AutogradTensor
+        import cakelamp._core as _core
+        ones = AutogradTensor(_core.ones(list(self.result.shape)), requires_grad=False)
+        return (grad_output * (ones - self.result * self.result),)
+
+
+class SumBackward(Function):
+    """Backward for sum (all elements)."""
+
+    def __init__(self):
+        super().__init__()
+        self.input_shape = None
+
+    def backward(self, grad_output):
+        from cakelamp.autograd.tensor import AutogradTensor
+        import cakelamp._core as _core
+        grad = AutogradTensor(_core.ones(list(self.input_shape)), requires_grad=False)
+        scalar_val = grad_output.item()
+        return (grad * AutogradTensor.from_scalar(scalar_val),)
+
+
+class SumDimBackward(Function):
+    """Backward for sum along a dimension."""
+
+    def __init__(self):
+        super().__init__()
+        self.input_shape = None
+        self.dim = None
+        self.keepdim = None
+
+    def backward(self, grad_output):
+        go = grad_output
+        if not self.keepdim:
+            go = go.unsqueeze(self.dim)
+        return (go.expand(list(self.input_shape)),)
+
+
+class MeanBackward(Function):
+    """Backward for mean (all elements)."""
+
+    def __init__(self):
+        super().__init__()
+        self.input_shape = None
+
+    def backward(self, grad_output):
+        from cakelamp.autograd.tensor import AutogradTensor
+        import cakelamp._core as _core
+        n = 1
+        for s in self.input_shape:
+            n *= s
+        grad = AutogradTensor(
+            _core.full(list(self.input_shape), 1.0 / n), requires_grad=False
+        )
+        scalar_val = grad_output.item()
+        return (grad * AutogradTensor.from_scalar(scalar_val),)
+
+
+class MeanDimBackward(Function):
+    """Backward for mean along a dimension."""
+
+    def __init__(self):
+        super().__init__()
+        self.input_shape = None
+        self.dim = None
+        self.keepdim = None
+
+    def backward(self, grad_output):
+        from cakelamp.autograd.tensor import AutogradTensor
+        go = grad_output
+        if not self.keepdim:
+            go = go.unsqueeze(self.dim)
+        dim_size = self.input_shape[self.dim]
+        scale = AutogradTensor.from_scalar(1.0 / dim_size)
+        return ((go * scale).expand(list(self.input_shape)),)
+
+
+class ReshapeBackward(Function):
+    """Backward for reshape."""
+
+    def __init__(self):
+        super().__init__()
+        self.input_shape = None
+
+    def backward(self, grad_output):
+        return (grad_output.reshape(list(self.input_shape)),)
+
+
+class TransposeBackward(Function):
+    """Backward for transpose."""
+
+    def __init__(self):
+        super().__init__()
+        self.dim0 = None
+        self.dim1 = None
+
+    def backward(self, grad_output):
+        return (grad_output.transpose(self.dim0, self.dim1),)
+
+
+class ExpandBackward(Function):
+    """Backward for expand."""
+
+    def __init__(self):
+        super().__init__()
+        self.input_shape = None
+
+    def backward(self, grad_output):
+        return (_unbroadcast(grad_output, self.input_shape),)
+
+
+class LogSoftmaxBackward(Function):
+    """Backward for log_softmax along a dimension."""
+
+    def __init__(self):
+        super().__init__()
+        self.result = None
+        self.dim = None
+
+    def backward(self, grad_output):
+        softmax = self.result.exp()
+        grad_sum = grad_output.sum_dim(self.dim, keepdim=True)
+        return (grad_output - softmax * grad_sum,)
+
+
+class SoftmaxBackward(Function):
+    """Backward for softmax along a dimension."""
+
+    def __init__(self):
+        super().__init__()
+        self.result = None
+        self.dim = None
+
+    def backward(self, grad_output):
+        s = self.result
+        sg = s * grad_output
+        sg_sum = sg.sum_dim(self.dim, keepdim=True)
+        return (s * (grad_output - sg_sum),)
+
+
+# ── Helper ────────────────────────────────────────────────────────────
+
+
+def _unbroadcast(grad, target_shape):
+    """Sum-reduce gradient to match target_shape after broadcasting."""
+    from cakelamp.autograd.tensor import AutogradTensor
+
+    grad_shape = list(grad.shape)
+    target_shape = list(target_shape)
+
+    if len(target_shape) == 0:
+        return grad.sum()
+
+    # Prepend 1s to match ndim
+    while len(target_shape) < len(grad_shape):
+        target_shape = [1] + target_shape
+
+    # Sum along broadcast dimensions
+    result = grad
+    for i in range(len(grad_shape)):
+        if target_shape[i] == 1 and grad_shape[i] != 1:
+            result = result.sum_dim(i, keepdim=True)
+
+    return result.reshape(list(target_shape))

--- a/python/cakelamp/autograd/tensor.py
+++ b/python/cakelamp/autograd/tensor.py
@@ -1,0 +1,385 @@
+"""AutogradTensor: Tensor with automatic differentiation support.
+
+Wraps the Rust-backed cakelamp._core.Tensor and adds:
+  - requires_grad: whether to track this tensor in the computation graph
+  - grad: accumulated gradient after backward()
+  - grad_fn: the Function node that created this tensor
+"""
+
+from __future__ import annotations
+from typing import Optional, List, Tuple
+import cakelamp._core as _core
+from cakelamp.autograd import function as F
+
+
+class AutogradTensor:
+    """Tensor with autograd support.
+
+    Wraps a cakelamp._core.Tensor (Rust) and layers Python-level
+    computation graph tracking on top.
+    """
+
+    def __init__(
+        self,
+        data: _core.Tensor,
+        requires_grad: bool = False,
+        grad_fn: Optional[F.Function] = None,
+    ):
+        self.data: _core.Tensor = data
+        self.requires_grad: bool = requires_grad
+        self.grad: Optional[AutogradTensor] = None
+        self.grad_fn: Optional[F.Function] = grad_fn
+        self._is_leaf = grad_fn is None
+
+    # ── Factory methods ──────────────────────────────────────────────
+
+    @staticmethod
+    def from_scalar(value: float, requires_grad: bool = False) -> AutogradTensor:
+        return AutogradTensor(_core.Tensor.scalar(value), requires_grad=requires_grad)
+
+    @staticmethod
+    def from_data(data: list, shape: list, requires_grad: bool = False) -> AutogradTensor:
+        return AutogradTensor(_core.tensor(data, shape), requires_grad=requires_grad)
+
+    @staticmethod
+    def zeros(shape: list, requires_grad: bool = False) -> AutogradTensor:
+        return AutogradTensor(_core.zeros(shape), requires_grad=requires_grad)
+
+    @staticmethod
+    def ones(shape: list, requires_grad: bool = False) -> AutogradTensor:
+        return AutogradTensor(_core.ones(shape), requires_grad=requires_grad)
+
+    @staticmethod
+    def rand(shape: list, requires_grad: bool = False) -> AutogradTensor:
+        return AutogradTensor(_core.rand(shape), requires_grad=requires_grad)
+
+    @staticmethod
+    def randn(shape: list, requires_grad: bool = False) -> AutogradTensor:
+        return AutogradTensor(_core.randn(shape), requires_grad=requires_grad)
+
+    @staticmethod
+    def full(shape: list, value: float, requires_grad: bool = False) -> AutogradTensor:
+        return AutogradTensor(_core.full(shape, value), requires_grad=requires_grad)
+
+    # ── Properties ───────────────────────────────────────────────────
+
+    @property
+    def shape(self) -> list:
+        return self.data.shape
+
+    @property
+    def ndim(self) -> int:
+        return self.data.ndim
+
+    @property
+    def is_leaf(self) -> bool:
+        return self._is_leaf
+
+    def numel(self) -> int:
+        return self.data.numel()
+
+    def item(self) -> float:
+        return self.data.item()
+
+    def tolist(self) -> list:
+        return self.data.tolist()
+
+    def detach(self) -> AutogradTensor:
+        return AutogradTensor(self.data, requires_grad=False)
+
+    def clone(self) -> AutogradTensor:
+        new_data = _core.tensor(self.data.tolist(), list(self.shape))
+        return AutogradTensor(new_data, requires_grad=self.requires_grad)
+
+    # ── Backward ─────────────────────────────────────────────────────
+
+    def backward(self, grad_output: Optional[AutogradTensor] = None):
+        """Run reverse-mode automatic differentiation."""
+        if grad_output is None:
+            if self.numel() != 1:
+                raise RuntimeError("backward() requires grad_output for non-scalar tensors")
+            grad_output = AutogradTensor(_core.ones(list(self.shape)), requires_grad=False)
+
+        topo_order = _topological_sort(self)
+        grads = {id(self): grad_output}
+
+        for node in topo_order:
+            if node.grad_fn is None:
+                continue
+            grad = grads.get(id(node))
+            if grad is None:
+                continue
+
+            input_grads = node.grad_fn.backward(grad)
+
+            for inp, ig in zip(node.grad_fn.inputs, input_grads):
+                if ig is None:
+                    continue
+                nid = id(inp)
+                if nid in grads:
+                    old = grads[nid]
+                    grads[nid] = AutogradTensor(old.data + ig.data, requires_grad=False)
+                else:
+                    grads[nid] = ig
+
+        for node in topo_order:
+            if node._is_leaf and node.requires_grad:
+                g = grads.get(id(node))
+                if g is not None:
+                    if node.grad is None:
+                        node.grad = g.detach()
+                    else:
+                        node.grad.data.add_(g.data)
+
+    def zero_grad(self):
+        self.grad = None
+
+    # ── Graph node creation helper ────────────────────────────────────
+
+    def _make_result(self, result_data, grad_fn_cls, inputs, **extra):
+        requires_grad = any(getattr(inp, "requires_grad", False) for inp in inputs)
+        grad_fn = None
+        if requires_grad:
+            grad_fn = grad_fn_cls()
+            grad_fn.inputs = list(inputs)
+            grad_fn.save_for_backward(*inputs)
+            for k, v in extra.items():
+                setattr(grad_fn, k, v)
+        return AutogradTensor(result_data, requires_grad=requires_grad, grad_fn=grad_fn)
+
+    # ── Arithmetic operators ─────────────────────────────────────────
+
+    def __add__(self, other) -> AutogradTensor:
+        other = _ensure_tensor(other)
+        return self._make_result(self.data + other.data, F.AddBackward, [self, other])
+
+    def __radd__(self, other) -> AutogradTensor:
+        return self.__add__(_ensure_tensor(other))
+
+    def __sub__(self, other) -> AutogradTensor:
+        other = _ensure_tensor(other)
+        return self._make_result(self.data - other.data, F.SubBackward, [self, other])
+
+    def __rsub__(self, other) -> AutogradTensor:
+        other = _ensure_tensor(other)
+        return other.__sub__(self)
+
+    def __mul__(self, other) -> AutogradTensor:
+        other = _ensure_tensor(other)
+        return self._make_result(self.data * other.data, F.MulBackward, [self, other])
+
+    def __rmul__(self, other) -> AutogradTensor:
+        return self.__mul__(_ensure_tensor(other))
+
+    def __truediv__(self, other) -> AutogradTensor:
+        other = _ensure_tensor(other)
+        return self._make_result(self.data / other.data, F.DivBackward, [self, other])
+
+    def __neg__(self) -> AutogradTensor:
+        return self._make_result(-self.data, F.NegBackward, [self])
+
+    def __matmul__(self, other) -> AutogradTensor:
+        return self.matmul(other)
+
+    # ── Unary operations ─────────────────────────────────────────────
+
+    def exp(self) -> AutogradTensor:
+        result = self._make_result(self.data.exp(), F.ExpBackward, [self])
+        if result.grad_fn:
+            result.grad_fn.result = result
+        return result
+
+    def log(self) -> AutogradTensor:
+        return self._make_result(self.data.log(), F.LogBackward, [self])
+
+    def relu(self) -> AutogradTensor:
+        return self._make_result(self.data.relu(), F.ReluBackward, [self])
+
+    def sigmoid(self) -> AutogradTensor:
+        result = self._make_result(self.data.sigmoid(), F.SigmoidBackward, [self])
+        if result.grad_fn:
+            result.grad_fn.result = result
+        return result
+
+    def tanh(self) -> AutogradTensor:
+        result = self._make_result(self.data.tanh(), F.TanhBackward, [self])
+        if result.grad_fn:
+            result.grad_fn.result = result
+        return result
+
+    def matmul(self, other) -> AutogradTensor:
+        other = _ensure_tensor(other)
+        return self._make_result(self.data.matmul(other.data), F.MatmulBackward, [self, other])
+
+    def softmax(self, dim: int = 1) -> AutogradTensor:
+        result = self._make_result(self.data.softmax(dim), F.SoftmaxBackward, [self], dim=dim)
+        if result.grad_fn:
+            result.grad_fn.result = result
+        return result
+
+    def log_softmax(self, dim: int = 1) -> AutogradTensor:
+        result = self._make_result(self.data.log_softmax(dim), F.LogSoftmaxBackward, [self], dim=dim)
+        if result.grad_fn:
+            result.grad_fn.result = result
+        return result
+
+    # ── Reduction operations ─────────────────────────────────────────
+
+    def sum(self) -> AutogradTensor:
+        return self._make_result(
+            self.data.sum(), F.SumBackward, [self], input_shape=tuple(self.shape)
+        )
+
+    def sum_dim(self, dim: int, keepdim: bool = False) -> AutogradTensor:
+        return self._make_result(
+            self.data.sum_dim(dim, keepdim), F.SumDimBackward, [self],
+            input_shape=tuple(self.shape), dim=dim, keepdim=keepdim
+        )
+
+    def mean(self) -> AutogradTensor:
+        return self._make_result(
+            self.data.mean(), F.MeanBackward, [self], input_shape=tuple(self.shape)
+        )
+
+    def mean_dim(self, dim: int, keepdim: bool = False) -> AutogradTensor:
+        return self._make_result(
+            self.data.mean_dim(dim, keepdim), F.MeanDimBackward, [self],
+            input_shape=tuple(self.shape), dim=dim, keepdim=keepdim
+        )
+
+    # ── View operations ──────────────────────────────────────────────
+
+    def reshape(self, shape: list) -> AutogradTensor:
+        return self._make_result(
+            self.data.reshape(shape), F.ReshapeBackward, [self],
+            input_shape=tuple(self.shape)
+        )
+
+    def transpose(self, dim0: int, dim1: int) -> AutogradTensor:
+        return self._make_result(
+            self.data.transpose(dim0, dim1), F.TransposeBackward, [self],
+            dim0=dim0, dim1=dim1
+        )
+
+    def t(self) -> AutogradTensor:
+        return self.transpose(0, 1)
+
+    def unsqueeze(self, dim: int) -> AutogradTensor:
+        return AutogradTensor(self.data.unsqueeze(dim), requires_grad=self.requires_grad, grad_fn=self.grad_fn)
+
+    def squeeze(self, dim: Optional[int] = None) -> AutogradTensor:
+        return AutogradTensor(self.data.squeeze(dim), requires_grad=self.requires_grad, grad_fn=self.grad_fn)
+
+    def expand(self, shape: list) -> AutogradTensor:
+        return self._make_result(
+            self.data.expand(shape), F.ExpandBackward, [self],
+            input_shape=tuple(self.shape)
+        )
+
+    def contiguous(self) -> AutogradTensor:
+        return AutogradTensor(self.data.contiguous(), requires_grad=self.requires_grad, grad_fn=self.grad_fn)
+
+    # ── Comparison / utility (not differentiable) ─────────────────────
+
+    def argmax(self, dim: int) -> AutogradTensor:
+        return AutogradTensor(self.data.argmax(dim), requires_grad=False)
+
+    def eq(self, other) -> AutogradTensor:
+        other = _ensure_tensor(other)
+        return AutogradTensor(self.data.eq(other.data), requires_grad=False)
+
+    def gt(self, other) -> AutogradTensor:
+        other = _ensure_tensor(other)
+        return AutogradTensor(self.data.gt(other.data), requires_grad=False)
+
+    def max(self) -> AutogradTensor:
+        return AutogradTensor(self.data.max(), requires_grad=False)
+
+    def min(self) -> AutogradTensor:
+        return AutogradTensor(self.data.min(), requires_grad=False)
+
+    # ── In-place operations (for optimizer use) ───────────────────────
+
+    def add_(self, other):
+        if isinstance(other, AutogradTensor):
+            self.data.add_(other.data)
+        else:
+            self.data.add_(other)
+        return self
+
+    def mul_scalar_(self, scalar: float):
+        self.data.mul_scalar_(scalar)
+        return self
+
+    def fill_(self, value: float):
+        self.data.fill_(value)
+        return self
+
+    def sub_alpha_(self, other, alpha: float):
+        if isinstance(other, AutogradTensor):
+            self.data.sub_alpha_(other.data, alpha)
+        else:
+            self.data.sub_alpha_(other, alpha)
+        return self
+
+    def copy_from(self, src):
+        if isinstance(src, AutogradTensor):
+            self.data.copy_from(src.data)
+        else:
+            self.data.copy_from(src)
+        return self
+
+    # ── Scalar ops ────────────────────────────────────────────────────
+
+    def add_scalar(self, s: float) -> AutogradTensor:
+        return AutogradTensor(self.data.add_scalar(s), requires_grad=self.requires_grad)
+
+    def mul_scalar(self, s: float) -> AutogradTensor:
+        return AutogradTensor(self.data.mul_scalar(s), requires_grad=self.requires_grad)
+
+    def get(self, indices: list) -> float:
+        return self.data.get(indices)
+
+    def set(self, indices: list, value: float):
+        self.data.set(indices, value)
+
+    # ── Repr ─────────────────────────────────────────────────────────
+
+    def __repr__(self) -> str:
+        return (
+            f"AutogradTensor(shape={self.shape}, "
+            f"requires_grad={self.requires_grad}, "
+            f"grad_fn={type(self.grad_fn).__name__ if self.grad_fn else None})"
+        )
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _ensure_tensor(x) -> AutogradTensor:
+    if isinstance(x, AutogradTensor):
+        return x
+    if isinstance(x, (int, float)):
+        return AutogradTensor.from_scalar(float(x))
+    if isinstance(x, _core.Tensor):
+        return AutogradTensor(x, requires_grad=False)
+    raise TypeError(f"Cannot convert {type(x)} to AutogradTensor")
+
+
+def _topological_sort(root: AutogradTensor) -> list:
+    """Topological sort of the computation graph (DFS post-order)."""
+    visited = set()
+    order = []
+
+    def _visit(node: AutogradTensor):
+        node_id = id(node)
+        if node_id in visited:
+            return
+        visited.add(node_id)
+        if node.grad_fn is not None:
+            for inp in node.grad_fn.inputs:
+                _visit(inp)
+        order.append(node)
+
+    _visit(root)
+    return list(reversed(order))

--- a/tests/test_autograd.py
+++ b/tests/test_autograd.py
@@ -1,0 +1,199 @@
+"""Tests for CakeLamp autograd (reverse-mode automatic differentiation)."""
+import math
+from cakelamp.autograd.tensor import AutogradTensor
+
+
+def approx(a, b, tol=1e-4):
+    return abs(a - b) < tol
+
+
+def approx_list(a, b, tol=1e-4):
+    assert len(a) == len(b), f"Length mismatch: {len(a)} != {len(b)}"
+    for i, (x, y) in enumerate(zip(a, b)):
+        assert abs(x - y) < tol, f"Mismatch at [{i}]: {x} != {y} (diff={abs(x-y)})"
+
+
+class TestBasicGradients:
+    def test_add_backward(self):
+        a = AutogradTensor.from_data([2.0, 3.0], [2], requires_grad=True)
+        b = AutogradTensor.from_data([4.0, 5.0], [2], requires_grad=True)
+        c = a + b
+        loss = c.sum()
+        loss.backward()
+        approx_list(a.grad.tolist(), [1.0, 1.0])
+        approx_list(b.grad.tolist(), [1.0, 1.0])
+
+    def test_sub_backward(self):
+        a = AutogradTensor.from_data([2.0, 3.0], [2], requires_grad=True)
+        b = AutogradTensor.from_data([4.0, 5.0], [2], requires_grad=True)
+        c = a - b
+        loss = c.sum()
+        loss.backward()
+        approx_list(a.grad.tolist(), [1.0, 1.0])
+        approx_list(b.grad.tolist(), [-1.0, -1.0])
+
+    def test_mul_backward(self):
+        a = AutogradTensor.from_data([2.0, 3.0], [2], requires_grad=True)
+        b = AutogradTensor.from_data([4.0, 5.0], [2], requires_grad=True)
+        c = a * b
+        loss = c.sum()
+        loss.backward()
+        approx_list(a.grad.tolist(), [4.0, 5.0])
+        approx_list(b.grad.tolist(), [2.0, 3.0])
+
+    def test_neg_backward(self):
+        a = AutogradTensor.from_data([2.0, 3.0], [2], requires_grad=True)
+        c = -a
+        loss = c.sum()
+        loss.backward()
+        approx_list(a.grad.tolist(), [-1.0, -1.0])
+
+
+class TestChainedGradients:
+    def test_chain_add_mul(self):
+        a = AutogradTensor.from_data([2.0], [1], requires_grad=True)
+        b = AutogradTensor.from_data([3.0], [1], requires_grad=True)
+        c = a + b
+        d = a * c  # d = a*(a+b) = a^2 + ab
+        loss = d.sum()
+        loss.backward()
+        assert approx(a.grad.tolist()[0], 7.0)  # 2a + b = 7
+        assert approx(b.grad.tolist()[0], 2.0)  # a = 2
+
+    def test_linear_layer(self):
+        x = AutogradTensor.from_data([1.0, 2.0], [1, 2], requires_grad=False)
+        W = AutogradTensor.from_data([0.5, 0.3, 0.2, 0.4], [2, 2], requires_grad=True)
+        b = AutogradTensor.from_data([0.1, 0.1], [1, 2], requires_grad=True)
+        y = x.matmul(W) + b
+        loss = y.sum()
+        loss.backward()
+        approx_list(W.grad.tolist(), [1.0, 1.0, 2.0, 2.0])
+        approx_list(b.grad.tolist(), [1.0, 1.0])
+
+
+class TestActivationGradients:
+    def test_relu_backward(self):
+        a = AutogradTensor.from_data([-1.0, 0.5, 2.0], [3], requires_grad=True)
+        r = a.relu()
+        loss = r.sum()
+        loss.backward()
+        approx_list(a.grad.tolist(), [0.0, 1.0, 1.0])
+
+    def test_exp_backward(self):
+        a = AutogradTensor.from_data([0.0, 1.0], [2], requires_grad=True)
+        r = a.exp()
+        loss = r.sum()
+        loss.backward()
+        assert approx(a.grad.tolist()[0], 1.0)
+        assert approx(a.grad.tolist()[1], math.e)
+
+    def test_log_backward(self):
+        a = AutogradTensor.from_data([1.0, 2.0, 4.0], [3], requires_grad=True)
+        r = a.log()
+        loss = r.sum()
+        loss.backward()
+        approx_list(a.grad.tolist(), [1.0, 0.5, 0.25])
+
+    def test_sigmoid_backward(self):
+        a = AutogradTensor.from_data([0.0], [1], requires_grad=True)
+        r = a.sigmoid()
+        loss = r.sum()
+        loss.backward()
+        assert approx(a.grad.tolist()[0], 0.25)
+
+    def test_tanh_backward(self):
+        a = AutogradTensor.from_data([0.0], [1], requires_grad=True)
+        r = a.tanh()
+        loss = r.sum()
+        loss.backward()
+        assert approx(a.grad.tolist()[0], 1.0)
+
+
+class TestReductionGradients:
+    def test_sum_backward(self):
+        a = AutogradTensor.from_data([1.0, 2.0, 3.0], [3], requires_grad=True)
+        loss = a.sum()
+        loss.backward()
+        approx_list(a.grad.tolist(), [1.0, 1.0, 1.0])
+
+    def test_mean_backward(self):
+        a = AutogradTensor.from_data([1.0, 2.0, 3.0, 4.0], [4], requires_grad=True)
+        loss = a.mean()
+        loss.backward()
+        approx_list(a.grad.tolist(), [0.25, 0.25, 0.25, 0.25])
+
+
+class TestMatmulGradients:
+    def test_matmul_backward(self):
+        A = AutogradTensor.from_data([1.0, 2.0, 3.0, 4.0], [2, 2], requires_grad=True)
+        B = AutogradTensor.from_data([5.0, 6.0, 7.0, 8.0], [2, 2], requires_grad=True)
+        C = A.matmul(B)
+        loss = C.sum()
+        loss.backward()
+        # dL/dA = ones(2,2) @ B^T = [[5,7],[6,8]] sum cols => [[11,15],[11,15]]
+        approx_list(A.grad.tolist(), [11.0, 15.0, 11.0, 15.0])
+        # dL/dB = A^T @ ones(2,2) = [[1,3],[2,4]] sum rows => [[4,4],[6,6]]
+        approx_list(B.grad.tolist(), [4.0, 4.0, 6.0, 6.0])
+
+
+class TestViewGradients:
+    def test_reshape_backward(self):
+        a = AutogradTensor.from_data([1.0, 2.0, 3.0, 4.0], [2, 2], requires_grad=True)
+        b = a.reshape([4])
+        loss = b.sum()
+        loss.backward()
+        approx_list(a.grad.tolist(), [1.0, 1.0, 1.0, 1.0])
+
+    def test_transpose_backward(self):
+        a = AutogradTensor.from_data([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3], requires_grad=True)
+        b = a.t()
+        loss = b.sum()
+        loss.backward()
+        approx_list(a.grad.tolist(), [1.0, 1.0, 1.0, 1.0, 1.0, 1.0])
+
+
+class TestNoGrad:
+    def test_no_grad_tensors(self):
+        a = AutogradTensor.from_data([1.0, 2.0], [2], requires_grad=False)
+        b = AutogradTensor.from_data([3.0, 4.0], [2], requires_grad=True)
+        c = a + b
+        loss = c.sum()
+        loss.backward()
+        assert a.grad is None
+        assert b.grad is not None
+
+    def test_detach(self):
+        a = AutogradTensor.from_data([1.0, 2.0], [2], requires_grad=True)
+        b = a.detach()
+        assert not b.requires_grad
+        assert b.grad_fn is None
+
+
+class TestZeroGrad:
+    def test_zero_grad(self):
+        a = AutogradTensor.from_data([1.0, 2.0], [2], requires_grad=True)
+        b = a * AutogradTensor.from_data([3.0, 4.0], [2])
+        loss = b.sum()
+        loss.backward()
+        assert a.grad is not None
+        a.zero_grad()
+        assert a.grad is None
+
+
+class TestMLP:
+    def test_simple_mlp_backward(self):
+        x = AutogradTensor.from_data([1.0, 2.0], [1, 2])
+        W1 = AutogradTensor.from_data([0.1, 0.2, 0.3, 0.4, 0.5, 0.6], [2, 3], requires_grad=True)
+        b1 = AutogradTensor.from_data([0.0, 0.0, 0.0], [1, 3], requires_grad=True)
+        W2 = AutogradTensor.from_data([0.7, 0.8, 0.9], [3, 1], requires_grad=True)
+        b2 = AutogradTensor.from_data([0.0], [1, 1], requires_grad=True)
+
+        h = x.matmul(W1) + b1
+        h = h.relu()
+        out = h.matmul(W2) + b2
+        loss = out.sum()
+        loss.backward()
+
+        for name, param in [("W1", W1), ("b1", b1), ("W2", W2), ("b2", b2)]:
+            assert param.grad is not None, f"{name} should have grad"
+            assert all(math.isfinite(v) for v in param.grad.tolist()), f"{name} grad not finite"


### PR DESCRIPTION
## Summary
- Pure Python autograd layer on top of Rust-backed tensor ops
- AutogradTensor with computation graph, backward(), grad tracking
- 18 backward functions for all differentiable ops
- Topological sort + reverse traversal engine
- Broadcasting gradient reduction
- In-place ops for optimizer compatibility
- Fixes pyproject.toml dependency-groups pip compatibility issue

## Test plan
- [x] 20 autograd tests: basic grads, chained, activations, reductions, matmul, views, MLP
- [x] 35 existing tensor tests still passing
- [x] Total: 55 tests passing

Build times: maturin develop ~7s, pytest 0.5s

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)