### PR TITLE
Add autograd: reverse-mode automatic differentiation

### DIFF
--- a/python/cakelamp/autograd/__init__.py
+++ b/python/cakelamp/autograd/__init__.py
@@ -1,0 +1,18 @@
+"""Autograd: Reverse-mode automatic differentiation for CakeLamp.
+
+The computation graph is built in Python. Each differentiable op creates
+a Function (Node) that records the inputs and knows how to compute
+the gradient. Tensor.backward() performs topological sort + reverse
+traversal to compute all gradients.
+"""
+
+from cakelamp.autograd.engine import no_grad, GradMode
+from cakelamp.autograd.tensor import AutogradTensor
+from cakelamp.autograd.function import Function
+
+__all__ = [
+    "AutogradTensor",
+    "Function",
+    "no_grad",
+    "GradMode",
+]

--- a/python/cakelamp/autograd/engine.py
+++ b/python/cakelamp/autograd/engine.py
@@ -1,0 +1,108 @@
+"""Autograd engine: gradient computation and context management."""
+
+
+class GradMode:
+    """Global gradient computation mode."""
+    _enabled = True
+
+    @classmethod
+    def is_enabled(cls):
+        return cls._enabled
+
+    @classmethod
+    def set_enabled(cls, mode):
+        cls._enabled = mode
+
+
+class no_grad:
+    """Context manager to disable gradient computation."""
+
+    def __enter__(self):
+        self.prev = GradMode.is_enabled()
+        GradMode.set_enabled(False)
+        return self
+
+    def __exit__(self, *args):
+        GradMode.set_enabled(self.prev)
+
+
+def backward(tensor, gradient=None):
+    """Run backward pass from a tensor through the computation graph.
+
+    Parameters
+    ----------
+    tensor : AutogradTensor
+        The output tensor to differentiate.
+    gradient : AutogradTensor, optional
+        External gradient. Defaults to ones for scalar tensors.
+    """
+    from cakelamp.autograd.tensor import AutogradTensor
+
+    if gradient is None:
+        if tensor.numel != 1:
+            raise RuntimeError(
+                "backward() requires scalar output or explicit gradient"
+            )
+        gradient = AutogradTensor.ones_like(tensor)
+
+    # Topological sort (reverse postorder)
+    topo_order = []
+    visited = set()
+
+    def _topo_sort(t):
+        if id(t) in visited:
+            return
+        visited.add(id(t))
+        if t._grad_fn is not None:
+            for parent in t._grad_fn.saved_tensors():
+                if isinstance(parent, AutogradTensor) and parent.requires_grad:
+                    _topo_sort(parent)
+            topo_order.append(t)
+
+    _topo_sort(tensor)
+    topo_order.reverse()
+
+    # Set output gradient
+    grads = {id(tensor): gradient}
+
+    # Backpropagate
+    for t in topo_order:
+        grad = grads.get(id(t))
+        if grad is None or t._grad_fn is None:
+            continue
+
+        input_grads = t._grad_fn.backward(grad)
+        parents = t._grad_fn.saved_tensors()
+
+        for parent, parent_grad in zip(parents, input_grads):
+            if not isinstance(parent, AutogradTensor):
+                continue
+            if not parent.requires_grad:
+                continue
+            if parent_grad is None:
+                continue
+
+            if id(parent) in grads:
+                grads[id(parent)] = grads[id(parent)] + parent_grad
+            else:
+                grads[id(parent)] = parent_grad
+
+    # Assign gradients to leaf tensors and all tensors with requires_grad
+    all_tensors = set()
+
+    def _collect(t):
+        all_tensors.add(id(t))
+        if t._grad_fn is not None:
+            for parent in t._grad_fn.saved_tensors():
+                if isinstance(parent, AutogradTensor) and id(parent) not in all_tensors:
+                    _collect(parent)
+
+    _collect(tensor)
+
+    for t in topo_order:
+        if id(t) in grads:
+            t.grad = grads[id(t)]
+        if t._grad_fn is not None:
+            for parent in t._grad_fn.saved_tensors():
+                if isinstance(parent, AutogradTensor) and id(parent) in grads:
+                    parent.grad = grads[id(parent)]

--- a/python/cakelamp/autograd/function.py
+++ b/python/cakelamp/autograd/function.py
@@ -1,0 +1,342 @@
+"""Autograd Function nodes for backward computation."""
+
+import math
+
+
+class Function:
+    """Base class for autograd function nodes."""
+
+    def saved_tensors(self):
+        """Return the input tensors this node depends on."""
+        raise NotImplementedError
+
+    def backward(self, grad_output):
+        """Compute gradients w.r.t. inputs. Returns list of gradients."""
+        raise NotImplementedError
+
+
+def _reduce_grad(grad, target_shape):
+    """Sum grad to match target_shape (undo broadcasting).
+
+    When a smaller tensor is broadcast to a larger shape for an op,
+    the gradient must be summed back along the broadcast dimensions.
+    """
+    from cakelamp.autograd.tensor import AutogradTensor
+
+    if not isinstance(grad, AutogradTensor):
+        return grad
+
+    grad_shape = list(grad._shape)
+    target = list(target_shape)
+
+    if grad_shape == target:
+        return grad
+
+    # Handle scalar target
+    if not target:
+        return grad.sum()
+
+    # Sum away leading dimensions
+    while len(grad_shape) > len(target):
+        grad = grad.sum(dim=0)
+        grad_shape = list(grad._shape)
+
+    # Sum along dimensions that were broadcast (size 1 in target)
+    for i in range(len(target)):
+        if target[i] == 1 and grad_shape[i] != 1:
+            grad = grad.sum(dim=i, keepdim=True)
+
+    return grad
+
+
+class AddBackward(Function):
+    def __init__(self, a, b):
+        self.a = a
+        self.b = b
+
+    def saved_tensors(self):
+        return [self.a, self.b]
+
+    def backward(self, grad_output):
+        return [
+            _reduce_grad(grad_output, self.a._shape),
+            _reduce_grad(grad_output, self.b._shape),
+        ]
+
+
+class SubBackward(Function):
+    def __init__(self, a, b):
+        self.a = a
+        self.b = b
+
+    def saved_tensors(self):
+        return [self.a, self.b]
+
+    def backward(self, grad_output):
+        return [
+            _reduce_grad(grad_output, self.a._shape),
+            _reduce_grad(-grad_output, self.b._shape),
+        ]
+
+
+class MulBackward(Function):
+    def __init__(self, a, b):
+        self.a = a
+        self.b = b
+
+    def saved_tensors(self):
+        return [self.a, self.b]
+
+    def backward(self, grad_output):
+        return [
+            _reduce_grad(grad_output * self.b.detach(), self.a._shape),
+            _reduce_grad(grad_output * self.a.detach(), self.b._shape),
+        ]
+
+
+class DivBackward(Function):
+    def __init__(self, a, b):
+        self.a = a
+        self.b = b
+
+    def saved_tensors(self):
+        return [self.a, self.b]
+
+    def backward(self, grad_output):
+        b_det = self.b.detach()
+        return [
+            _reduce_grad(grad_output / b_det, self.a._shape),
+            _reduce_grad(-grad_output * self.a.detach() / (b_det * b_det), self.b._shape),
+        ]
+
+
+class NegBackward(Function):
+    def __init__(self, a):
+        self.a = a
+
+    def saved_tensors(self):
+        return [self.a]
+
+    def backward(self, grad_output):
+        return [-grad_output]
+
+
+class PowBackward(Function):
+    def __init__(self, base, exponent):
+        self.base = base
+        self.exponent = exponent
+
+    def saved_tensors(self):
+        return [self.base, self.exponent]
+
+    def backward(self, grad_output):
+        b = self.base.detach()
+        e = self.exponent.detach()
+        grad_base = _reduce_grad(
+            grad_output * e * (b ** (e - 1)),
+            self.base._shape,
+        )
+        grad_exp = None
+        if self.exponent.requires_grad:
+            grad_exp = _reduce_grad(
+                grad_output * (b ** e) * b.log(),
+                self.exponent._shape,
+            )
+        return [grad_base, grad_exp]
+
+
+class ExpBackward(Function):
+    def __init__(self, input_t, output_t):
+        self.input = input_t
+        self.output = output_t
+
+    def saved_tensors(self):
+        return [self.input]
+
+    def backward(self, grad_output):
+        return [grad_output * self.output.detach()]
+
+
+class LogBackward(Function):
+    def __init__(self, input_t):
+        self.input = input_t
+
+    def saved_tensors(self):
+        return [self.input]
+
+    def backward(self, grad_output):
+        return [grad_output / self.input.detach()]
+
+
+class ReluBackward(Function):
+    def __init__(self, input_t):
+        self.input = input_t
+
+    def saved_tensors(self):
+        return [self.input]
+
+    def backward(self, grad_output):
+        from cakelamp.autograd.tensor import AutogradTensor
+        mask_data = [1.0 if x > 0 else 0.0 for x in self.input._data]
+        mask = AutogradTensor._make(mask_data, list(self.input._shape))
+        return [grad_output * mask]
+
+
+class SigmoidBackward(Function):
+    def __init__(self, input_t, output_t):
+        self.input = input_t
+        self.output = output_t
+
+    def saved_tensors(self):
+        return [self.input]
+
+    def backward(self, grad_output):
+        from cakelamp.autograd.tensor import AutogradTensor
+        s = self.output.detach()
+        ones = AutogradTensor.ones_like(s)
+        return [grad_output * s * (ones - s)]
+
+
+class TanhBackward(Function):
+    def __init__(self, input_t, output_t):
+        self.input = input_t
+        self.output = output_t
+
+    def saved_tensors(self):
+        return [self.input]
+
+    def backward(self, grad_output):
+        from cakelamp.autograd.tensor import AutogradTensor
+        t = self.output.detach()
+        ones = AutogradTensor.ones_like(t)
+        return [grad_output * (ones - t * t)]
+
+
+class SumBackward(Function):
+    def __init__(self, input_t, dim=None, keepdim=False):
+        self.input = input_t
+        self.dim = dim
+        self.keepdim = keepdim
+
+    def saved_tensors(self):
+        return [self.input]
+
+    def backward(self, grad_output):
+        from cakelamp.autograd.tensor import AutogradTensor
+        if self.dim is None:
+            return [AutogradTensor.ones(list(self.input._shape)) * grad_output]
+        else:
+            if not self.keepdim:
+                g = grad_output.unsqueeze(self.dim)
+            else:
+                g = grad_output
+            return [g.expand(list(self.input._shape))]
+
+
+class MeanBackward(Function):
+    def __init__(self, input_t, dim=None, keepdim=False):
+        self.input = input_t
+        self.dim = dim
+        self.keepdim = keepdim
+
+    def saved_tensors(self):
+        return [self.input]
+
+    def backward(self, grad_output):
+        from cakelamp.autograd.tensor import AutogradTensor
+        if self.dim is None:
+            n = self.input.numel
+            return [AutogradTensor.ones(list(self.input._shape)) * grad_output / n]
+        else:
+            n = self.input._shape[self.dim]
+            if not self.keepdim:
+                g = grad_output.unsqueeze(self.dim)
+            else:
+                g = grad_output
+            return [g.expand(list(self.input._shape)) / n]
+
+
+class MatmulBackward(Function):
+    def __init__(self, a, b):
+        self.a = a
+        self.b = b
+
+    def saved_tensors(self):
+        return [self.a, self.b]
+
+    def backward(self, grad_output):
+        # d(A @ B)/dA = grad @ B^T, d(A @ B)/dB = A^T @ grad
+        return [
+            grad_output.mm(self.b.detach().transpose(0, 1)),
+            self.a.detach().transpose(0, 1).mm(grad_output),
+        ]
+
+
+class ReshapeBackward(Function):
+    def __init__(self, input_t):
+        self.input = input_t
+
+    def saved_tensors(self):
+        return [self.input]
+
+    def backward(self, grad_output):
+        return [grad_output.reshape(list(self.input._shape))]
+
+
+class TransposeBackward(Function):
+    def __init__(self, input_t, dim0, dim1):
+        self.input = input_t
+        self.dim0 = dim0
+        self.dim1 = dim1
+
+    def saved_tensors(self):
+        return [self.input]
+
+    def backward(self, grad_output):
+        return [grad_output.transpose(self.dim0, self.dim1)]
+
+
+class LogSoftmaxBackward(Function):
+    def __init__(self, input_t, softmax_output, dim):
+        self.input = input_t
+        self.softmax = softmax_output
+        self.dim = dim
+
+    def saved_tensors(self):
+        return [self.input]
+
+    def backward(self, grad_output):
+        sm = self.softmax
+        grad_sum = grad_output.sum(dim=self.dim, keepdim=True)
+        return [grad_output - sm * grad_sum.expand(list(self.input._shape))]
+
+
+class CrossEntropyBackward(Function):
+    """Backward for cross-entropy loss (combined log_softmax + nll)."""
+
+    def __init__(self, input_t, target, softmax_output):
+        self.input = input_t
+        self.target = target
+        self.softmax = softmax_output
+
+    def saved_tensors(self):
+        return [self.input]
+
+    def backward(self, grad_output):
+        from cakelamp.autograd.tensor import AutogradTensor
+        batch_size = self.input._shape[0]
+        num_classes = self.input._shape[1]
+
+        sm_data = list(self.softmax._data)
+        target_data = self.target._data
+
+        grad_data = sm_data[:]
+        for i in range(batch_size):
+            c = int(target_data[i])
+            grad_data[i * num_classes + c] -= 1.0
+
+        go = grad_output.item() if grad_output.numel == 1 else 1.0
+        scale = go / batch_size
+        grad_data = [x * scale for x in grad_data]
+
+        return [AutogradTensor._make(grad_data, list(self.input._shape))]

--- a/python/cakelamp/autograd/tensor.py
+++ b/python/cakelamp/autograd/tensor.py
@@ -1,0 +1,777 @@
+"""AutogradTensor: A tensor with automatic differentiation support.
+
+This is a pure Python tensor that provides the computation backend
+needed for autograd. It mirrors the Rust/PyO3 Tensor API but adds
+requires_grad, grad, and grad_fn for reverse-mode autodiff.
+"""
+
+import math
+import random
+import builtins
+
+from cakelamp.autograd.engine import GradMode
+
+
+class AutogradTensor:
+    """Tensor with autograd support.
+
+    Stores data as a flat list of floats with shape/stride metadata.
+    Tracks computation graph via grad_fn for backward().
+    """
+
+    __slots__ = ('_data', '_shape', '_strides', '_offset',
+                 'requires_grad', 'grad', '_grad_fn', '_version')
+
+    def __init__(self, data, requires_grad=False):
+        if isinstance(data, (list, tuple)):
+            flat, shape = _flatten(data)
+            self._data = [float(x) for x in flat]
+            self._shape = list(shape)
+        elif isinstance(data, (int, float)):
+            self._data = [float(data)]
+            self._shape = []
+        else:
+            raise TypeError(f"Unsupported data type: {type(data)}")
+        self._strides = _compute_strides(self._shape)
+        self._offset = 0
+        self.requires_grad = requires_grad
+        self.grad = None
+        self._grad_fn = None
+        self._version = 0
+
+    @staticmethod
+    def _make(data, shape, requires_grad=False):
+        t = AutogradTensor.__new__(AutogradTensor)
+        t._data = data
+        t._shape = list(shape)
+        t._strides = _compute_strides(shape)
+        t._offset = 0
+        t.requires_grad = requires_grad
+        t.grad = None
+        t._grad_fn = None
+        t._version = 0
+        return t
+
+    # ---- Constructors ----
+
+    @staticmethod
+    def zeros(shape, requires_grad=False):
+        n = _numel(shape)
+        return AutogradTensor._make([0.0] * n, shape, requires_grad)
+
+    @staticmethod
+    def ones(shape, requires_grad=False):
+        n = _numel(shape)
+        return AutogradTensor._make([1.0] * n, shape, requires_grad)
+
+    @staticmethod
+    def ones_like(tensor):
+        return AutogradTensor.ones(list(tensor._shape))
+
+    @staticmethod
+    def zeros_like(tensor):
+        return AutogradTensor.zeros(list(tensor._shape))
+
+    @staticmethod
+    def rand(shape, requires_grad=False):
+        n = _numel(shape)
+        return AutogradTensor._make([random.random() for _ in range(n)], shape, requires_grad)
+
+    @staticmethod
+    def randn(shape, requires_grad=False):
+        n = _numel(shape)
+        data = []
+        for _ in range(n):
+            u1 = max(random.random(), 1e-10)
+            u2 = random.random()
+            data.append(math.sqrt(-2.0 * math.log(u1)) * math.cos(2 * math.pi * u2))
+        return AutogradTensor._make(data, shape, requires_grad)
+
+    @staticmethod
+    def full(shape, value, requires_grad=False):
+        n = _numel(shape)
+        return AutogradTensor._make([float(value)] * n, shape, requires_grad)
+
+    @staticmethod
+    def eye(n, requires_grad=False):
+        data = [0.0] * (n * n)
+        for i in range(n):
+            data[i * n + i] = 1.0
+        return AutogradTensor._make(data, [n, n], requires_grad)
+
+    @staticmethod
+    def arange(start, end, step=1.0):
+        data = []
+        v = float(start)
+        end = float(end)
+        step = float(step)
+        if step > 0:
+            while v < end:
+                data.append(v)
+                v += step
+        elif step < 0:
+            while v > end:
+                data.append(v)
+                v += step
+        return AutogradTensor._make(data, [len(data)])
+
+    # ---- Properties ----
+
+    @property
+    def shape(self):
+        return tuple(self._shape)
+
+    @property
+    def ndim(self):
+        return len(self._shape)
+
+    @property
+    def numel(self):
+        return _numel(self._shape)
+
+    @property
+    def data(self):
+        t = AutogradTensor._make(list(self._data), list(self._shape))
+        return t
+
+    @data.setter
+    def data(self, value):
+        if isinstance(value, AutogradTensor):
+            self._data = list(value._data)
+            self._shape = list(value._shape)
+            self._strides = _compute_strides(self._shape)
+            self._offset = 0
+            self._version += 1
+        else:
+            raise TypeError("data must be an AutogradTensor")
+
+    def item(self):
+        assert self.numel == 1, f"item() requires single-element tensor, got {self.numel}"
+        if not self._shape:
+            return self._data[self._offset]
+        return self._data[0]
+
+    def detach(self):
+        t = AutogradTensor._make(list(self._data), list(self._shape))
+        return t
+
+    def clone(self):
+        t = AutogradTensor._make(list(self._data), list(self._shape), self.requires_grad)
+        return t
+
+    def tolist(self):
+        if not self._shape:
+            return self._data[0] if self._data else 0.0
+        def _build(data, shape, offset):
+            if len(shape) == 1:
+                return [data[offset + i] for i in range(shape[0])]
+            stride = _numel(shape[1:])
+            return [_build(data, shape[1:], offset + i * stride) for i in range(shape[0])]
+        return _build(self._data, self._shape, 0)
+
+    # ---- Shape ops ----
+
+    def reshape(self, *shape):
+        if len(shape) == 1 and isinstance(shape[0], (list, tuple)):
+            shape = list(shape[0])
+        else:
+            shape = list(shape)
+        # Handle -1
+        neg_idx = None
+        known = 1
+        for i, s in enumerate(shape):
+            if s == -1:
+                neg_idx = i
+            else:
+                known *= s
+        if neg_idx is not None:
+            shape[neg_idx] = self.numel // known
+        assert _numel(shape) == self.numel
+        from cakelamp.autograd.function import ReshapeBackward
+        result = AutogradTensor._make(list(self._data), shape, self.requires_grad)
+        if self.requires_grad and GradMode.is_enabled():
+            result._grad_fn = ReshapeBackward(self)
+        return result
+
+    def view(self, *shape):
+        return self.reshape(*shape)
+
+    def transpose(self, dim0, dim1):
+        from cakelamp.autograd.function import TransposeBackward
+        new_shape = list(self._shape)
+        new_shape[dim0], new_shape[dim1] = new_shape[dim1], new_shape[dim0]
+        # Need to physically rearrange data
+        ndim = len(self._shape)
+        n = self.numel
+        old_strides = _compute_strides(self._shape)
+        new_strides_logical = list(old_strides)
+        new_strides_logical[dim0], new_strides_logical[dim1] = new_strides_logical[dim1], new_strides_logical[dim0]
+        # Materialize transposed data
+        new_data = [0.0] * n
+        coord = [0] * ndim
+        for i in range(n):
+            old_idx = sum(coord[d] * old_strides[d] for d in range(ndim))
+            new_coord = list(coord)
+            new_coord[dim0], new_coord[dim1] = new_coord[dim1], new_coord[dim0]
+            new_idx = sum(new_coord[d] * _compute_strides(new_shape)[d] for d in range(ndim))
+            new_data[new_idx] = self._data[old_idx]
+            for d in range(ndim - 1, -1, -1):
+                coord[d] += 1
+                if coord[d] < self._shape[d]:
+                    break
+                coord[d] = 0
+
+        result = AutogradTensor._make(new_data, new_shape, self.requires_grad)
+        if self.requires_grad and GradMode.is_enabled():
+            result._grad_fn = TransposeBackward(self, dim0, dim1)
+        return result
+
+    @property
+    def T(self):
+        assert self.ndim == 2
+        return self.transpose(0, 1)
+
+    def unsqueeze(self, dim):
+        new_shape = list(self._shape)
+        if dim < 0:
+            dim = self.ndim + 1 + dim
+        new_shape.insert(dim, 1)
+        return AutogradTensor._make(list(self._data), new_shape, self.requires_grad)
+
+    def squeeze(self, dim=None):
+        new_shape = [s for i, s in enumerate(self._shape)
+                     if not ((dim is None and s == 1) or (dim is not None and i == dim and s == 1))]
+        return AutogradTensor._make(list(self._data), new_shape, self.requires_grad)
+
+    def expand(self, *shape):
+        if len(shape) == 1 and isinstance(shape[0], (list, tuple)):
+            shape = list(shape[0])
+        else:
+            shape = list(shape)
+        # Broadcast self._data to target shape
+        target = shape
+        src_shape = list(self._shape)
+        # Pad src_shape on the left
+        while len(src_shape) < len(target):
+            src_shape = [1] + src_shape
+
+        n = _numel(target)
+        src_strides = _compute_strides(src_shape)
+        # Zero out strides where src dim is 1 and target dim > 1
+        bc_strides = list(src_strides)
+        for i in range(len(target)):
+            if src_shape[i] == 1 and target[i] > 1:
+                bc_strides[i] = 0
+
+        result = [0.0] * n
+        ndim = len(target)
+        coord = [0] * ndim
+        for flat_i in range(n):
+            src_idx = sum(coord[d] * bc_strides[d] for d in range(ndim))
+            result[flat_i] = self._data[src_idx]
+            for d in range(ndim - 1, -1, -1):
+                coord[d] += 1
+                if coord[d] < target[d]:
+                    break
+                coord[d] = 0
+        return AutogradTensor._make(result, target, self.requires_grad)
+
+    # ---- Element-wise ops ----
+
+    def __add__(self, other):
+        from cakelamp.autograd.function import AddBackward
+        other = _ensure_tensor(other)
+        data, shape = _binary_op(self._data, self._shape, other._data, other._shape, lambda a, b: a + b)
+        rg = self.requires_grad or other.requires_grad
+        result = AutogradTensor._make(data, shape, rg)
+        if rg and GradMode.is_enabled():
+            result._grad_fn = AddBackward(self, other)
+        return result
+
+    def __radd__(self, other):
+        return self.__add__(other)
+
+    def __sub__(self, other):
+        from cakelamp.autograd.function import SubBackward
+        other = _ensure_tensor(other)
+        data, shape = _binary_op(self._data, self._shape, other._data, other._shape, lambda a, b: a - b)
+        rg = self.requires_grad or other.requires_grad
+        result = AutogradTensor._make(data, shape, rg)
+        if rg and GradMode.is_enabled():
+            result._grad_fn = SubBackward(self, other)
+        return result
+
+    def __rsub__(self, other):
+        return _ensure_tensor(other).__sub__(self)
+
+    def __mul__(self, other):
+        from cakelamp.autograd.function import MulBackward
+        other = _ensure_tensor(other)
+        data, shape = _binary_op(self._data, self._shape, other._data, other._shape, lambda a, b: a * b)
+        rg = self.requires_grad or other.requires_grad
+        result = AutogradTensor._make(data, shape, rg)
+        if rg and GradMode.is_enabled():
+            result._grad_fn = MulBackward(self, other)
+        return result
+
+    def __rmul__(self, other):
+        return self.__mul__(other)
+
+    def __truediv__(self, other):
+        from cakelamp.autograd.function import DivBackward
+        other = _ensure_tensor(other)
+        data, shape = _binary_op(self._data, self._shape, other._data, other._shape, lambda a, b: a / b)
+        rg = self.requires_grad or other.requires_grad
+        result = AutogradTensor._make(data, shape, rg)
+        if rg and GradMode.is_enabled():
+            result._grad_fn = DivBackward(self, other)
+        return result
+
+    def __rtruediv__(self, other):
+        return _ensure_tensor(other).__truediv__(self)
+
+    def __neg__(self):
+        from cakelamp.autograd.function import NegBackward
+        data = [-x for x in self._data]
+        result = AutogradTensor._make(data, list(self._shape), self.requires_grad)
+        if self.requires_grad and GradMode.is_enabled():
+            result._grad_fn = NegBackward(self)
+        return result
+
+    def __pow__(self, other):
+        from cakelamp.autograd.function import PowBackward
+        other = _ensure_tensor(other)
+        data, shape = _binary_op(self._data, self._shape, other._data, other._shape, lambda a, b: a ** b)
+        rg = self.requires_grad or other.requires_grad
+        result = AutogradTensor._make(data, shape, rg)
+        if rg and GradMode.is_enabled():
+            result._grad_fn = PowBackward(self, other)
+        return result
+
+    def exp(self):
+        from cakelamp.autograd.function import ExpBackward
+        data = [math.exp(x) for x in self._data]
+        result = AutogradTensor._make(data, list(self._shape), self.requires_grad)
+        if self.requires_grad and GradMode.is_enabled():
+            result._grad_fn = ExpBackward(self, result)
+        return result
+
+    def log(self):
+        from cakelamp.autograd.function import LogBackward
+        data = [math.log(x) for x in self._data]
+        result = AutogradTensor._make(data, list(self._shape), self.requires_grad)
+        if self.requires_grad and GradMode.is_enabled():
+            result._grad_fn = LogBackward(self)
+        return result
+
+    def relu(self):
+        from cakelamp.autograd.function import ReluBackward
+        data = [builtins.max(0.0, x) for x in self._data]
+        result = AutogradTensor._make(data, list(self._shape), self.requires_grad)
+        if self.requires_grad and GradMode.is_enabled():
+            result._grad_fn = ReluBackward(self)
+        return result
+
+    def sigmoid(self):
+        from cakelamp.autograd.function import SigmoidBackward
+        data = [1.0 / (1.0 + math.exp(-x)) for x in self._data]
+        result = AutogradTensor._make(data, list(self._shape), self.requires_grad)
+        if self.requires_grad and GradMode.is_enabled():
+            result._grad_fn = SigmoidBackward(self, result)
+        return result
+
+    def tanh(self):
+        from cakelamp.autograd.function import TanhBackward
+        data = [math.tanh(x) for x in self._data]
+        result = AutogradTensor._make(data, list(self._shape), self.requires_grad)
+        if self.requires_grad and GradMode.is_enabled():
+            result._grad_fn = TanhBackward(self, result)
+        return result
+
+    def sqrt(self):
+        return self ** 0.5
+
+    def clamp(self, min_val=None, max_val=None):
+        def _c(x):
+            if min_val is not None: x = builtins.max(x, min_val)
+            if max_val is not None: x = builtins.min(x, max_val)
+            return x
+        return AutogradTensor._make([_c(x) for x in self._data], list(self._shape), self.requires_grad)
+
+    # ---- Reduction ops ----
+
+    def sum(self, dim=None, keepdim=False):
+        from cakelamp.autograd.function import SumBackward
+        if dim is None:
+            s = builtins.sum(self._data)
+            result = AutogradTensor._make([s], [], self.requires_grad)
+        else:
+            data, shape = _sum_dim(self._data, self._shape, dim, keepdim)
+            result = AutogradTensor._make(data, shape, self.requires_grad)
+        if self.requires_grad and GradMode.is_enabled():
+            result._grad_fn = SumBackward(self, dim, keepdim)
+        return result
+
+    def mean(self, dim=None, keepdim=False):
+        from cakelamp.autograd.function import MeanBackward
+        if dim is None:
+            s = builtins.sum(self._data) / len(self._data)
+            result = AutogradTensor._make([s], [], self.requires_grad)
+        else:
+            data, shape = _sum_dim(self._data, self._shape, dim, keepdim)
+            n = self._shape[dim]
+            data = [x / n for x in data]
+            result = AutogradTensor._make(data, shape, self.requires_grad)
+        if self.requires_grad and GradMode.is_enabled():
+            result._grad_fn = MeanBackward(self, dim, keepdim)
+        return result
+
+    def argmax(self, dim=None):
+        if dim is None:
+            best = 0
+            for i in range(1, len(self._data)):
+                if self._data[i] > self._data[best]:
+                    best = i
+            return AutogradTensor._make([float(best)], [])
+        return _argmax_dim(self._data, self._shape, dim)
+
+    # ---- Matrix ops ----
+
+    def mm(self, other):
+        from cakelamp.autograd.function import MatmulBackward
+        assert self.ndim == 2 and other.ndim == 2
+        m, k = self._shape
+        k2, n = other._shape
+        assert k == k2
+        result_data = [0.0] * (m * n)
+        for i in range(m):
+            for p in range(k):
+                a_val = self._data[i * k + p]
+                for j in range(n):
+                    result_data[i * n + j] += a_val * other._data[p * n + j]
+        rg = self.requires_grad or other.requires_grad
+        result = AutogradTensor._make(result_data, [m, n], rg)
+        if rg and GradMode.is_enabled():
+            result._grad_fn = MatmulBackward(self, other)
+        return result
+
+    def matmul(self, other):
+        return self.mm(other)
+
+    def __matmul__(self, other):
+        return self.mm(other)
+
+    # ---- Softmax ----
+
+    def softmax(self, dim=-1):
+        if dim < 0:
+            dim = self.ndim + dim
+        data, shape = _softmax(self._data, self._shape, dim)
+        return AutogradTensor._make(data, shape, self.requires_grad)
+
+    def log_softmax(self, dim=-1):
+        from cakelamp.autograd.function import LogSoftmaxBackward
+        if dim < 0:
+            dim = self.ndim + dim
+        sm_data, sm_shape = _softmax(self._data, self._shape, dim)
+        log_data = [math.log(builtins.max(x, 1e-12)) for x in sm_data]
+        result = AutogradTensor._make(log_data, sm_shape, self.requires_grad)
+        if self.requires_grad and GradMode.is_enabled():
+            sm = AutogradTensor._make(sm_data, sm_shape)
+            result._grad_fn = LogSoftmaxBackward(self, sm, dim)
+        return result
+
+    # ---- In-place ops ----
+
+    def add_(self, other):
+        other = _ensure_tensor(other)
+        result = self + other
+        self._data = list(result._data)
+        self._shape = list(result._shape)
+        self._strides = _compute_strides(self._shape)
+        self._version += 1
+        return self
+
+    def mul_(self, other):
+        other = _ensure_tensor(other)
+        result = self * other
+        self._data = list(result._data)
+        self._shape = list(result._shape)
+        self._strides = _compute_strides(self._shape)
+        self._version += 1
+        return self
+
+    def zero_(self):
+        self._data = [0.0] * self.numel
+        self._version += 1
+        return self
+
+    def fill_(self, val):
+        self._data = [float(val)] * self.numel
+        self._version += 1
+        return self
+
+    # ---- Backward ----
+
+    def backward(self, gradient=None):
+        from cakelamp.autograd.engine import backward
+        backward(self, gradient)
+
+    # ---- Comparison ----
+
+    def __eq__(self, other):
+        other = _ensure_tensor(other)
+        data, shape = _binary_op(self._data, self._shape, other._data, other._shape,
+                                 lambda a, b: 1.0 if abs(a - b) < 1e-7 else 0.0)
+        return AutogradTensor._make(data, shape)
+
+    def __gt__(self, other):
+        other = _ensure_tensor(other)
+        data, shape = _binary_op(self._data, self._shape, other._data, other._shape,
+                                 lambda a, b: 1.0 if a > b else 0.0)
+        return AutogradTensor._make(data, shape)
+
+    # ---- Repr ----
+
+    def __repr__(self):
+        if not self._shape:
+            return f"tensor({self._data[0]:.4f})"
+        if self.numel <= 20:
+            return f"tensor({self.tolist()}, shape={self.shape})"
+        return f"tensor(shape={self.shape})"
+
+    def __len__(self):
+        if not self._shape:
+            raise TypeError("len() of 0-d tensor")
+        return self._shape[0]
+
+    def __getitem__(self, idx):
+        if isinstance(idx, int):
+            if idx < 0:
+                idx += self._shape[0]
+            new_shape = self._shape[1:]
+            n = _numel(new_shape) if new_shape else 1
+            start = idx * n
+            new_data = self._data[start:start + n]
+            return AutogradTensor._make(new_data, new_shape, self.requires_grad)
+        raise NotImplementedError("Only int indexing supported")
+
+
+# ---- Utility functions ----
+
+def _ensure_tensor(x):
+    if isinstance(x, AutogradTensor):
+        return x
+    if isinstance(x, (int, float)):
+        return AutogradTensor._make([float(x)], [])
+    raise TypeError(f"Cannot convert {type(x)} to AutogradTensor")
+
+
+def _flatten(data):
+    if not isinstance(data, (list, tuple)):
+        return [data], ()
+    if len(data) == 0:
+        return [], (0,)
+    sub_results = []
+    sub_shape = None
+    for item in data:
+        flat, shape = _flatten(item)
+        if sub_shape is not None and shape != sub_shape:
+            raise ValueError("Inconsistent shapes")
+        sub_shape = shape
+        sub_results.extend(flat)
+    return sub_results, (len(data),) + sub_shape
+
+
+def _compute_strides(shape):
+    if not shape:
+        return []
+    ndim = len(shape)
+    strides = [1] * ndim
+    for i in range(ndim - 2, -1, -1):
+        strides[i] = strides[i + 1] * shape[i + 1]
+    return strides
+
+
+def _numel(shape):
+    r = 1
+    for s in shape:
+        r *= s
+    return r
+
+
+def _broadcast_shape(a, b):
+    ndim = builtins.max(len(a), len(b))
+    result = [0] * ndim
+    for i in range(ndim):
+        da = a[i - ndim + len(a)] if i >= ndim - len(a) else 1
+        db = b[i - ndim + len(b)] if i >= ndim - len(b) else 1
+        if da == db:
+            result[i] = da
+        elif da == 1:
+            result[i] = db
+        elif db == 1:
+            result[i] = da
+        else:
+            raise ValueError(f"Cannot broadcast {a} and {b}")
+    return result
+
+
+def _broadcast_strides(shape, strides, target):
+    ndim = len(target)
+    pad = ndim - len(shape)
+    result = [0] * ndim
+    for i in range(len(shape)):
+        ni = i + pad
+        if shape[i] == target[ni]:
+            result[ni] = strides[i]
+        elif shape[i] == 1:
+            result[ni] = 0
+        else:
+            raise ValueError(f"Cannot broadcast dim {i}")
+    return result
+
+
+def _binary_op(a_data, a_shape, b_data, b_shape, op):
+    out_shape = _broadcast_shape(a_shape, b_shape)
+    a_strides = _broadcast_strides(a_shape, _compute_strides(a_shape), out_shape)
+    b_strides = _broadcast_strides(b_shape, _compute_strides(b_shape), out_shape)
+    n = _numel(out_shape)
+    ndim = len(out_shape)
+    result = [0.0] * n
+    if ndim == 0:
+        return [op(a_data[0], b_data[0])], []
+    coord = [0] * ndim
+    for fi in range(n):
+        ai = builtins.sum(coord[d] * a_strides[d] for d in range(ndim))
+        bi = builtins.sum(coord[d] * b_strides[d] for d in range(ndim))
+        result[fi] = op(a_data[ai], b_data[bi])
+        for d in range(ndim - 1, -1, -1):
+            coord[d] += 1
+            if coord[d] < out_shape[d]:
+                break
+            coord[d] = 0
+    return result, out_shape
+
+
+def _sum_dim(data, shape, dim, keepdim):
+    ndim = len(shape)
+    dim_size = shape[dim]
+    out_shape = list(shape)
+    out_shape[dim] = 1
+    out_n = _numel(out_shape)
+    result = [0.0] * out_n
+    in_strides = _compute_strides(shape)
+    out_strides = _compute_strides(out_shape)
+
+    coord = [0] * ndim
+    for _ in range(out_n):
+        out_idx = builtins.sum(coord[d] * out_strides[d] for d in range(ndim))
+        s = 0.0
+        for k in range(dim_size):
+            in_idx = builtins.sum(
+                (k if d == dim else coord[d]) * in_strides[d]
+                for d in range(ndim)
+            )
+            s += data[in_idx]
+        result[out_idx] = s
+        for d in range(ndim - 1, -1, -1):
+            if d == dim:
+                continue
+            coord[d] += 1
+            if coord[d] < out_shape[d]:
+                break
+            coord[d] = 0
+
+    if keepdim:
+        return result, out_shape
+    else:
+        squeezed = [s for i, s in enumerate(out_shape) if i != dim]
+        if not squeezed:
+            return result, []
+        return result, squeezed
+
+
+def _argmax_dim(data, shape, dim):
+    ndim = len(shape)
+    dim_size = shape[dim]
+    out_shape = [s for i, s in enumerate(shape) if i != dim]
+    if not out_shape:
+        best = 0
+        for i in range(1, len(data)):
+            if data[i] > data[best]:
+                best = i
+        return AutogradTensor._make([float(best)], [])
+    out_n = _numel(out_shape)
+    result = [0.0] * out_n
+    in_strides = _compute_strides(shape)
+    coord = [0] * len(out_shape)
+    for oi in range(out_n):
+        best_val = float('-inf')
+        best_idx = 0
+        for k in range(dim_size):
+            in_idx = 0
+            od = 0
+            for d in range(ndim):
+                if d == dim:
+                    in_idx += k * in_strides[d]
+                else:
+                    in_idx += coord[od] * in_strides[d]
+                    od += 1
+            if data[in_idx] > best_val:
+                best_val = data[in_idx]
+                best_idx = k
+        result[oi] = float(best_idx)
+        for d in range(len(out_shape) - 1, -1, -1):
+            coord[d] += 1
+            if coord[d] < out_shape[d]:
+                break
+            coord[d] = 0
+    return AutogradTensor._make(result, out_shape)
+
+
+def _softmax(data, shape, dim):
+    ndim = len(shape)
+    n = _numel(shape)
+    strides = _compute_strides(shape)
+    out_shape = list(shape)
+    out_shape[dim] = 1
+    out_n = _numel(out_shape)
+    out_strides = _compute_strides(out_shape)
+
+    maxes = [float('-inf')] * out_n
+    coord = [0] * ndim
+    for _ in range(n):
+        in_idx = builtins.sum(coord[d] * strides[d] for d in range(ndim))
+        out_idx = builtins.sum(coord[d] * out_strides[d] for d in range(ndim) if d != dim)
+        if data[in_idx] > maxes[out_idx]:
+            maxes[out_idx] = data[in_idx]
+        for d in range(ndim - 1, -1, -1):
+            coord[d] += 1
+            if coord[d] < shape[d]: break
+            coord[d] = 0
+
+    exp_sums = [0.0] * out_n
+    result = [0.0] * n
+    coord = [0] * ndim
+    for fi in range(n):
+        in_idx = builtins.sum(coord[d] * strides[d] for d in range(ndim))
+        out_idx = builtins.sum(coord[d] * out_strides[d] for d in range(ndim) if d != dim)
+        e = math.exp(data[in_idx] - maxes[out_idx])
+        result[fi] = e
+        exp_sums[out_idx] += e
+        for d in range(ndim - 1, -1, -1):
+            coord[d] += 1
+            if coord[d] < shape[d]: break
+            coord[d] = 0
+
+    coord = [0] * ndim
+    for fi in range(n):
+        out_idx = builtins.sum(coord[d] * out_strides[d] for d in range(ndim) if d != dim)
+        result[fi] /= exp_sums[out_idx]
+        for d in range(ndim - 1, -1, -1):
+            coord[d] += 1
+            if coord[d] < shape[d]: break
+            coord[d] = 0
+
+    return result, list(shape)

--- a/tests/test_autograd.py
+++ b/tests/test_autograd.py
@@ -1,0 +1,567 @@
+"""Tests for cakelamp.autograd — reverse-mode automatic differentiation."""
+
+import math
+import pytest
+
+from cakelamp.autograd.tensor import AutogradTensor
+from cakelamp.autograd.engine import backward, no_grad, GradMode
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _flat(t):
+    """Get flat data from a tensor."""
+    return list(t._data)
+
+
+def _approx(a, b, tol=1e-4):
+    """Check two flat lists are element-wise close."""
+    assert len(a) == len(b), f"Length mismatch: {len(a)} vs {len(b)}"
+    for i, (x, y) in enumerate(zip(a, b)):
+        assert abs(x - y) < tol, f"Index {i}: {x} != {y} (tol={tol})"
+
+
+def _numerical_grad(f, x_data, shape, eps=1e-5):
+    """Compute numerical gradient via central differences."""
+    grads = []
+    for i in range(len(x_data)):
+        x_plus = list(x_data)
+        x_plus[i] += eps
+        x_minus = list(x_data)
+        x_minus[i] -= eps
+        t_plus = AutogradTensor._make(x_plus, list(shape))
+        t_minus = AutogradTensor._make(x_minus, list(shape))
+        fp = f(t_plus).item()
+        fm = f(t_minus).item()
+        grads.append((fp - fm) / (2 * eps))
+    return grads
+
+
+# ===========================================================================
+# 1. Tensor basics
+# ===========================================================================
+
+class TestTensorBasics:
+    def test_create_from_list(self):
+        t = AutogradTensor([1.0, 2.0, 3.0])
+        assert t._shape == [3]
+        assert t.numel == 3
+        _approx(_flat(t), [1.0, 2.0, 3.0])
+
+    def test_create_2d(self):
+        t = AutogradTensor([[1.0, 2.0], [3.0, 4.0]])
+        assert t._shape == [2, 2]
+        assert t.numel == 4
+
+    def test_zeros(self):
+        t = AutogradTensor.zeros([2, 3])
+        assert t._shape == [2, 3]
+        _approx(_flat(t), [0.0] * 6)
+
+    def test_ones(self):
+        t = AutogradTensor.ones([3])
+        _approx(_flat(t), [1.0, 1.0, 1.0])
+
+    def test_full(self):
+        t = AutogradTensor.full([2, 2], 5.0)
+        _approx(_flat(t), [5.0] * 4)
+
+    def test_eye(self):
+        t = AutogradTensor.eye(3)
+        expected = [1, 0, 0, 0, 1, 0, 0, 0, 1]
+        _approx(_flat(t), [float(x) for x in expected])
+
+    def test_arange(self):
+        t = AutogradTensor.arange(0, 5, 1)
+        _approx(_flat(t), [0.0, 1.0, 2.0, 3.0, 4.0])
+
+    def test_rand_shape(self):
+        t = AutogradTensor.rand([2, 3])
+        assert t._shape == [2, 3]
+        assert t.numel == 6
+
+    def test_item_scalar(self):
+        t = AutogradTensor([42.0])
+        assert t.item() == pytest.approx(42.0)
+
+    def test_requires_grad(self):
+        t = AutogradTensor([1.0], requires_grad=True)
+        assert t.requires_grad is True
+        t2 = AutogradTensor([1.0])
+        assert t2.requires_grad is False
+
+    def test_detach(self):
+        t = AutogradTensor([1.0, 2.0], requires_grad=True)
+        d = t.detach()
+        assert d.requires_grad is False
+        assert d._grad_fn is None
+
+
+# ===========================================================================
+# 2. Forward ops (no grad check, just correctness)
+# ===========================================================================
+
+class TestForwardOps:
+    def test_add(self):
+        a = AutogradTensor([1.0, 2.0])
+        b = AutogradTensor([3.0, 4.0])
+        c = a + b
+        _approx(_flat(c), [4.0, 6.0])
+
+    def test_sub(self):
+        a = AutogradTensor([5.0, 3.0])
+        b = AutogradTensor([1.0, 2.0])
+        c = a - b
+        _approx(_flat(c), [4.0, 1.0])
+
+    def test_mul(self):
+        a = AutogradTensor([2.0, 3.0])
+        b = AutogradTensor([4.0, 5.0])
+        c = a * b
+        _approx(_flat(c), [8.0, 15.0])
+
+    def test_div(self):
+        a = AutogradTensor([6.0, 8.0])
+        b = AutogradTensor([2.0, 4.0])
+        c = a / b
+        _approx(_flat(c), [3.0, 2.0])
+
+    def test_neg(self):
+        a = AutogradTensor([1.0, -2.0])
+        c = -a
+        _approx(_flat(c), [-1.0, 2.0])
+
+    def test_pow(self):
+        a = AutogradTensor([2.0, 3.0])
+        b = AutogradTensor([3.0, 2.0])
+        c = a ** b
+        _approx(_flat(c), [8.0, 9.0])
+
+    def test_exp(self):
+        a = AutogradTensor([0.0, 1.0])
+        c = a.exp()
+        _approx(_flat(c), [1.0, math.e])
+
+    def test_log(self):
+        a = AutogradTensor([1.0, math.e])
+        c = a.log()
+        _approx(_flat(c), [0.0, 1.0])
+
+    def test_relu(self):
+        a = AutogradTensor([-1.0, 0.0, 2.0])
+        c = a.relu()
+        _approx(_flat(c), [0.0, 0.0, 2.0])
+
+    def test_sigmoid(self):
+        a = AutogradTensor([0.0])
+        c = a.sigmoid()
+        assert c.item() == pytest.approx(0.5)
+
+    def test_tanh(self):
+        a = AutogradTensor([0.0])
+        c = a.tanh()
+        assert c.item() == pytest.approx(0.0)
+
+    def test_matmul(self):
+        a = AutogradTensor([[1.0, 2.0], [3.0, 4.0]])
+        b = AutogradTensor([[5.0, 6.0], [7.0, 8.0]])
+        c = a.mm(b)
+        _approx(_flat(c), [19.0, 22.0, 43.0, 50.0])
+
+    def test_sum_all(self):
+        a = AutogradTensor([1.0, 2.0, 3.0])
+        s = a.sum()
+        assert s.item() == pytest.approx(6.0)
+
+    def test_sum_dim(self):
+        a = AutogradTensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        s = a.sum(dim=0)
+        _approx(_flat(s), [5.0, 7.0, 9.0])
+
+    def test_mean_all(self):
+        a = AutogradTensor([2.0, 4.0, 6.0])
+        m = a.mean()
+        assert m.item() == pytest.approx(4.0)
+
+    def test_reshape(self):
+        a = AutogradTensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        b = a.reshape([2, 3])
+        assert b._shape == [2, 3]
+        _approx(_flat(b), [1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+
+    def test_transpose(self):
+        a = AutogradTensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        b = a.transpose(0, 1)
+        assert b._shape == [3, 2]
+        # After transpose, contiguous data should be column-major read
+        _approx(_flat(b), [1.0, 4.0, 2.0, 5.0, 3.0, 6.0])
+
+    def test_softmax(self):
+        a = AutogradTensor([[1.0, 2.0, 3.0]])
+        s = a.softmax(dim=1)
+        vals = _flat(s)
+        assert sum(vals) == pytest.approx(1.0, abs=1e-5)
+        assert vals[0] < vals[1] < vals[2]
+
+    def test_log_softmax(self):
+        a = AutogradTensor([[1.0, 2.0, 3.0]])
+        ls = a.log_softmax(dim=1)
+        vals = _flat(ls)
+        for v in vals:
+            assert v <= 0.0 + 1e-6
+        assert sum(math.exp(v) for v in vals) == pytest.approx(1.0, abs=1e-5)
+
+
+# ===========================================================================
+# 3. Backward passes — numerical gradient checks
+# ===========================================================================
+
+class TestBackwardNumerical:
+    """Verify analytic gradients match numerical (central difference) gradients."""
+
+    def _check_grad(self, f, x_data, shape, tol=1e-3):
+        x = AutogradTensor._make(list(x_data), list(shape), requires_grad=True)
+        loss = f(x)
+        loss.backward()
+        analytic = _flat(x.grad)
+        numerical = _numerical_grad(f, x_data, shape)
+        _approx(analytic, numerical, tol=tol)
+
+    def test_add_backward(self):
+        def f(x):
+            return (x + x).sum()
+        self._check_grad(f, [1.0, 2.0, 3.0], [3])
+
+    def test_sub_backward(self):
+        def f(x):
+            c = AutogradTensor([5.0, 5.0, 5.0])
+            return (c - x).sum()
+        self._check_grad(f, [1.0, 2.0, 3.0], [3])
+
+    def test_mul_backward(self):
+        def f(x):
+            return (x * x).sum()
+        self._check_grad(f, [1.0, 2.0, 3.0], [3])
+
+    def test_div_backward(self):
+        def f(x):
+            c = AutogradTensor([1.0, 1.0])
+            return (c / x).sum()
+        self._check_grad(f, [2.0, 3.0], [2])
+
+    def test_neg_backward(self):
+        def f(x):
+            return (-x).sum()
+        self._check_grad(f, [1.0, -2.0, 3.0], [3])
+
+    def test_pow_backward(self):
+        def f(x):
+            e = AutogradTensor([2.0, 3.0])
+            return (x ** e).sum()
+        self._check_grad(f, [2.0, 3.0], [2])
+
+    def test_exp_backward(self):
+        def f(x):
+            return x.exp().sum()
+        self._check_grad(f, [0.0, 1.0, -1.0], [3])
+
+    def test_log_backward(self):
+        def f(x):
+            return x.log().sum()
+        self._check_grad(f, [1.0, 2.0, 3.0], [3])
+
+    def test_relu_backward(self):
+        def f(x):
+            return x.relu().sum()
+        self._check_grad(f, [-1.0, 0.5, 2.0], [3])
+
+    def test_sigmoid_backward(self):
+        def f(x):
+            return x.sigmoid().sum()
+        self._check_grad(f, [-1.0, 0.0, 1.0], [3])
+
+    def test_tanh_backward(self):
+        def f(x):
+            return x.tanh().sum()
+        self._check_grad(f, [-1.0, 0.0, 1.0], [3])
+
+    def test_sum_backward(self):
+        def f(x):
+            return x.sum()
+        self._check_grad(f, [1.0, 2.0, 3.0, 4.0], [4])
+
+    def test_mean_backward(self):
+        def f(x):
+            return x.mean()
+        self._check_grad(f, [1.0, 2.0, 3.0, 4.0], [4])
+
+    def test_matmul_backward(self):
+        """Gradient of sum(A @ B) w.r.t. A."""
+        B = AutogradTensor._make([1.0, 0.0, 0.0, 1.0], [2, 2])
+
+        def f(x):
+            return x.reshape([2, 2]).mm(B).sum()
+        self._check_grad(f, [1.0, 2.0, 3.0, 4.0], [4])
+
+    def test_chain_rule(self):
+        """Multi-step computation: exp(x * x).sum()."""
+        def f(x):
+            return (x * x).exp().sum()
+        self._check_grad(f, [0.5, 1.0, -0.5], [3], tol=1e-2)
+
+    def test_complex_chain(self):
+        """sigmoid(x) * tanh(x) summed."""
+        def f(x):
+            return (x.sigmoid() * x.tanh()).sum()
+        self._check_grad(f, [-1.0, 0.0, 1.0], [3])
+
+
+# ===========================================================================
+# 4. Specific backward correctness
+# ===========================================================================
+
+class TestBackwardExact:
+    def test_add_grad_values(self):
+        a = AutogradTensor([2.0, 3.0], requires_grad=True)
+        b = AutogradTensor([4.0, 5.0], requires_grad=True)
+        c = (a + b).sum()
+        c.backward()
+        _approx(_flat(a.grad), [1.0, 1.0])
+        _approx(_flat(b.grad), [1.0, 1.0])
+
+    def test_mul_grad_values(self):
+        a = AutogradTensor([2.0, 3.0], requires_grad=True)
+        b = AutogradTensor([4.0, 5.0], requires_grad=True)
+        c = (a * b).sum()
+        c.backward()
+        _approx(_flat(a.grad), [4.0, 5.0])
+        _approx(_flat(b.grad), [2.0, 3.0])
+
+    def test_sub_grad_values(self):
+        a = AutogradTensor([2.0, 3.0], requires_grad=True)
+        b = AutogradTensor([4.0, 5.0], requires_grad=True)
+        c = (a - b).sum()
+        c.backward()
+        _approx(_flat(a.grad), [1.0, 1.0])
+        _approx(_flat(b.grad), [-1.0, -1.0])
+
+    def test_div_grad_values(self):
+        a = AutogradTensor([6.0], requires_grad=True)
+        b = AutogradTensor([3.0], requires_grad=True)
+        c = (a / b).sum()
+        c.backward()
+        _approx(_flat(a.grad), [1.0 / 3.0])
+        _approx(_flat(b.grad), [-6.0 / 9.0])
+
+    def test_neg_grad_values(self):
+        a = AutogradTensor([1.0, 2.0], requires_grad=True)
+        c = (-a).sum()
+        c.backward()
+        _approx(_flat(a.grad), [-1.0, -1.0])
+
+    def test_relu_grad_values(self):
+        a = AutogradTensor([-1.0, 0.5, 2.0], requires_grad=True)
+        c = a.relu().sum()
+        c.backward()
+        _approx(_flat(a.grad), [0.0, 1.0, 1.0])
+
+    def test_matmul_grad_values(self):
+        a = AutogradTensor._make([1.0, 2.0, 3.0, 4.0], [2, 2], requires_grad=True)
+        b = AutogradTensor._make([5.0, 6.0, 7.0, 8.0], [2, 2], requires_grad=True)
+        c = a.mm(b).sum()
+        c.backward()
+        # grad_A = ones(2,2) @ B^T
+        # B^T = [[5,7],[6,8]], ones@B^T row = [5+6, 7+8] = [11, 15]
+        _approx(_flat(a.grad), [11.0, 15.0, 11.0, 15.0])
+        # grad_B = A^T @ ones(2,2)
+        # A^T = [[1,3],[2,4]], A^T@ones col = [1+3, 2+4] = [4, 6]
+        _approx(_flat(b.grad), [4.0, 4.0, 6.0, 6.0])
+
+
+# ===========================================================================
+# 5. Gradient accumulation & graph
+# ===========================================================================
+
+class TestGradAccumulation:
+    def test_same_tensor_used_twice(self):
+        x = AutogradTensor([2.0, 3.0], requires_grad=True)
+        y = x * x
+        z = y + x
+        loss = z.sum()
+        loss.backward()
+        # d_loss/dx = 2x + 1 = [5, 7]
+        _approx(_flat(x.grad), [5.0, 7.0])
+
+    def test_grad_not_set_without_requires_grad(self):
+        a = AutogradTensor([1.0, 2.0])
+        b = AutogradTensor([3.0, 4.0], requires_grad=True)
+        c = (a + b).sum()
+        c.backward()
+        assert a.grad is None
+        _approx(_flat(b.grad), [1.0, 1.0])
+
+
+# ===========================================================================
+# 6. no_grad context
+# ===========================================================================
+
+class TestNoGrad:
+    def test_no_grad_disables_tracking(self):
+        x = AutogradTensor([1.0, 2.0], requires_grad=True)
+        with no_grad():
+            y = x + x
+        assert y._grad_fn is None
+
+    def test_no_grad_restores(self):
+        assert GradMode.is_enabled()
+        with no_grad():
+            assert not GradMode.is_enabled()
+        assert GradMode.is_enabled()
+
+
+# ===========================================================================
+# 7. Shape operations backward
+# ===========================================================================
+
+class TestShapeOpsBackward:
+    def test_reshape_backward(self):
+        x = AutogradTensor._make([1.0, 2.0, 3.0, 4.0], [4], requires_grad=True)
+        y = x.reshape([2, 2])
+        loss = y.sum()
+        loss.backward()
+        assert x.grad._shape == [4]
+        _approx(_flat(x.grad), [1.0, 1.0, 1.0, 1.0])
+
+    def test_transpose_backward(self):
+        x = AutogradTensor._make([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3], requires_grad=True)
+        y = x.transpose(0, 1)
+        loss = y.sum()
+        loss.backward()
+        assert x.grad._shape == [2, 3]
+        _approx(_flat(x.grad), [1.0] * 6)
+
+    def test_sum_dim_backward(self):
+        x = AutogradTensor._make([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3], requires_grad=True)
+        y = x.sum(dim=1)
+        loss = y.sum()
+        loss.backward()
+        _approx(_flat(x.grad), [1.0] * 6)
+
+    def test_mean_dim_backward(self):
+        x = AutogradTensor._make([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3], requires_grad=True)
+        y = x.mean(dim=1)
+        loss = y.sum()
+        loss.backward()
+        _approx(_flat(x.grad), [1.0 / 3] * 6)
+
+
+# ===========================================================================
+# 8. Broadcasting backward
+# ===========================================================================
+
+class TestBroadcastBackward:
+    def test_add_broadcast_scalar(self):
+        a = AutogradTensor._make([2.0], [1], requires_grad=True)
+        b = AutogradTensor([1.0, 2.0, 3.0], requires_grad=True)
+        c = (a + b).sum()
+        c.backward()
+        _approx(_flat(a.grad), [3.0])
+        _approx(_flat(b.grad), [1.0, 1.0, 1.0])
+
+    def test_mul_broadcast(self):
+        """(1,3) * (2,3) => (2,3)."""
+        a = AutogradTensor._make([1.0, 2.0, 3.0], [1, 3], requires_grad=True)
+        b = AutogradTensor._make([1.0, 1.0, 1.0, 2.0, 2.0, 2.0], [2, 3], requires_grad=True)
+        c = (a * b).sum()
+        c.backward()
+        _approx(_flat(a.grad), [3.0, 3.0, 3.0])
+
+
+# ===========================================================================
+# 9. Log-softmax backward
+# ===========================================================================
+
+class TestLogSoftmaxBackward:
+    def test_log_softmax_backward(self):
+        def f(x):
+            return x.reshape([1, 3]).log_softmax(dim=1).sum()
+        x_data = [1.0, 2.0, 3.0]
+        x = AutogradTensor._make(list(x_data), [3], requires_grad=True)
+        loss = f(x)
+        loss.backward()
+        numerical = _numerical_grad(f, x_data, [3])
+        _approx(_flat(x.grad), numerical, tol=1e-3)
+
+
+# ===========================================================================
+# 10. In-place ops
+# ===========================================================================
+
+class TestInplaceOps:
+    def test_zero_(self):
+        t = AutogradTensor([1.0, 2.0, 3.0])
+        t.zero_()
+        _approx(_flat(t), [0.0, 0.0, 0.0])
+
+    def test_fill_(self):
+        t = AutogradTensor([0.0, 0.0])
+        t.fill_(7.0)
+        _approx(_flat(t), [7.0, 7.0])
+
+    def test_add_inplace(self):
+        t = AutogradTensor([1.0, 2.0])
+        t.add_(AutogradTensor([3.0, 4.0]))
+        _approx(_flat(t), [4.0, 6.0])
+
+    def test_mul_inplace(self):
+        t = AutogradTensor([2.0, 3.0])
+        t.mul_(AutogradTensor([4.0, 5.0]))
+        _approx(_flat(t), [8.0, 15.0])
+
+
+# ===========================================================================
+# 11. Integration: simple linear regression
+# ===========================================================================
+
+class TestIntegration:
+    def test_linear_regression_convergence(self):
+        """Train y = 2x + 1 using manual SGD on AutogradTensor."""
+        w = AutogradTensor([0.0], requires_grad=True)
+        b = AutogradTensor([0.0], requires_grad=True)
+
+        lr = 0.01
+        xs = [1.0, 2.0, 3.0, 4.0]
+        ys = [3.0, 5.0, 7.0, 9.0]
+
+        for epoch in range(200):
+            total_loss = AutogradTensor([0.0])
+            for x_val, y_val in zip(xs, ys):
+                x = AutogradTensor([x_val])
+                y = AutogradTensor([y_val])
+                pred = x * w + b
+                diff = pred - y
+                loss = diff * diff
+                total_loss = total_loss + loss
+
+            total_loss.backward()
+
+            with no_grad():
+                w_data = w._data[0] - lr * w.grad._data[0]
+                b_data = b._data[0] - lr * b.grad._data[0]
+                w._data[0] = w_data
+                b._data[0] = b_data
+
+            w.grad = None
+            b.grad = None
+
+        assert w.item() == pytest.approx(2.0, abs=0.1)
+        assert b.item() == pytest.approx(1.0, abs=0.1)
+
+    def test_backward_requires_scalar(self):
+        """backward() without gradient should fail for non-scalar."""
+        t = AutogradTensor([1.0, 2.0], requires_grad=True)
+        y = t * t
+        with pytest.raises(RuntimeError):
+            y.backward()


### PR DESCRIPTION
## Summary
- Adds `python/cakelamp/autograd/` module implementing reverse-mode automatic differentiation
- Pure Python `AutogradTensor` with computation graph tracking, backward pass via topological sort
- 18 backward Function nodes: Add, Sub, Mul, Div, Neg, Pow, Exp, Log, ReLU, Sigmoid, Tanh, Sum, Mean, Matmul, Reshape, Transpose, LogSoftmax, CrossEntropy
- Broadcasting support with gradient reduction (`_reduce_grad`)
- `no_grad` context manager and `GradMode` for controlling gradient tracking
- 70 new tests including numerical gradient checks and a linear regression integration test

Closes #3

## Test plan
- [x] All 70 autograd tests pass (`uv run pytest tests/test_autograd.py -v`)
- [x] Full test suite (201 tests) passes (`uv run pytest tests/ -v`, 0.5s)
- [x] Numerical gradient checks verify analytic gradients match central differences
- [x] Linear regression converges to correct weights (y=2x+1)

Build time: `uv run pytest tests/ -v`: 0.5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)