### PR TITLE
Add tiled matmul, cache-friendly bmm, autograd benchmarks

### DIFF
--- a/benchmarks/bench_autograd.py
+++ b/benchmarks/bench_autograd.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Autograd-level benchmarks for CakeLamp.
+
+Times forward and backward passes through the autograd layer,
+including Linear layers, MLP architectures, and loss functions.
+Run with: python benchmarks/bench_autograd.py
+
+All benchmarks use CakeLamp only -- no external ML library comparisons.
+"""
+
+import time
+import statistics
+from cakelamp.autograd.tensor import AutogradTensor
+from cakelamp.autograd.engine import no_grad
+
+
+def bench(name, fn, warmup=3, iterations=20):
+    """Run a benchmark and report timing statistics."""
+    for _ in range(warmup):
+        fn()
+
+    times = []
+    for _ in range(iterations):
+        start = time.perf_counter()
+        fn()
+        elapsed = time.perf_counter() - start
+        times.append(elapsed * 1000)  # ms
+
+    mean = statistics.mean(times)
+    std = statistics.stdev(times) if len(times) > 1 else 0
+    median = statistics.median(times)
+    best = min(times)
+    print(f"  {name:50s}  mean={mean:8.3f}ms  median={median:8.3f}ms  best={best:8.3f}ms")
+
+
+def main():
+    print("=" * 95)
+    print("CakeLamp Autograd Benchmarks")
+    print("=" * 95)
+
+    # --- Forward pass ---
+    print("\n--- Forward Pass ---\n")
+
+    x32 = AutogradTensor.randn([32, 784])
+    w1 = AutogradTensor.randn([784, 128], requires_grad=True)
+    b1 = AutogradTensor.randn([1, 128])
+    w2 = AutogradTensor.randn([128, 10], requires_grad=True)
+    b2 = AutogradTensor.randn([1, 10])
+
+    def linear_fwd():
+        return x32.mm(w1) + b1
+
+    bench("Linear forward 32x784 -> 128", linear_fwd)
+
+    def mlp_fwd():
+        h = (x32.mm(w1) + b1).relu()
+        return h.mm(w2) + b2
+
+    bench("MLP forward 784->128->10 batch=32", mlp_fwd)
+
+    # --- Forward + Backward ---
+    print("\n--- Forward + Backward ---\n")
+
+    def linear_fwd_bwd():
+        out = x32.mm(w1) + b1
+        loss = out.sum()
+        loss.backward()
+        w1.grad = None
+
+    bench("Linear fwd+bwd 32x784 -> 128", linear_fwd_bwd)
+
+    def mlp_fwd_bwd():
+        h = (x32.mm(w1) + b1).relu()
+        out = h.mm(w2) + b2
+        loss = out.sum()
+        loss.backward()
+        w1.grad = None
+        w2.grad = None
+
+    bench("MLP fwd+bwd 784->128->10 batch=32", mlp_fwd_bwd, warmup=2, iterations=10)
+
+    # --- Cross-entropy loss ---
+    print("\n--- Loss Computation ---\n")
+
+    logits = AutogradTensor.randn([32, 10], requires_grad=True)
+
+    def softmax_fwd_bwd():
+        ls = logits.log_softmax(dim=1)
+        loss = (-ls).sum()
+        loss.backward()
+        logits.grad = None
+
+    bench("log_softmax fwd+bwd 32x10", softmax_fwd_bwd)
+
+    # --- Reduction operations with autograd ---
+    print("\n--- Reduction Ops (with grad tracking) ---\n")
+
+    big = AutogradTensor.randn([64, 784], requires_grad=True)
+
+    def sum_fwd_bwd():
+        loss = big.sum()
+        loss.backward()
+        big.grad = None
+
+    bench("sum fwd+bwd 64x784", sum_fwd_bwd)
+
+    def mean_fwd_bwd():
+        loss = big.mean()
+        loss.backward()
+        big.grad = None
+
+    bench("mean fwd+bwd 64x784", mean_fwd_bwd)
+
+    # --- no_grad overhead ---
+    print("\n--- no_grad Context ---\n")
+
+    a = AutogradTensor.randn([1000], requires_grad=True)
+    b = AutogradTensor.randn([1000], requires_grad=True)
+
+    def with_grad():
+        return (a + b).sum()
+
+    def without_grad():
+        with no_grad():
+            return (a + b).sum()
+
+    bench("add+sum 1000 (with grad)", with_grad)
+    bench("add+sum 1000 (no_grad)", without_grad)
+
+    print("\n" + "=" * 95)
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/cakelamp-core/src/ops.rs
+++ b/crates/cakelamp-core/src/ops.rs
@@ -342,9 +342,12 @@ pub fn argmax(a: &Tensor, dim: usize) -> Tensor {
 /// Matrix multiplication for 2D tensors.
 /// a: (M, K), b: (K, N) -> result: (M, N)
 ///
-/// Uses ikj loop order for cache-friendly access patterns:
-/// - Inner loop traverses columns of result and B contiguously in memory.
-/// - This avoids cache misses from column-striding through B (as in ijk order).
+/// Uses cache-friendly tiled ikj loop ordering:
+/// - Tile size (32) chosen to keep 3 tiles (A, B, result) in L1 cache (~32KB).
+///   3 * 32 * 32 * 4 bytes = 12KB, well within L1.
+/// - ikj order ensures sequential memory access for both B and result rows.
+/// - Tiling ensures temporal locality: each tile of B is reused across
+///   multiple rows of A before being evicted from cache.
 pub fn matmul(a: &Tensor, b: &Tensor) -> Tensor {
     assert_eq!(a.ndim(), 2, "matmul requires 2D tensors");
     assert_eq!(b.ndim(), 2, "matmul requires 2D tensors");
@@ -353,22 +356,40 @@ pub fn matmul(a: &Tensor, b: &Tensor) -> Tensor {
     let n = b.shape()[1];
     assert_eq!(k, b.shape()[0], "Inner dimensions must match for matmul");
 
-    let a_data = a.to_vec();
+    let a_data = a.contiguous().to_vec();
     let b_data = b.contiguous().to_vec();
     let mut result = vec![0.0f32; m * n];
 
-    // ikj loop order: for each row i, accumulate a[i,p] * b[p,:] into result[i,:]
-    // This makes the inner loop stride contiguously through both result and b_data.
-    for i in 0..m {
-        let res_row = i * n;
-        let a_row = i * k;
-        for p in 0..k {
-            let a_val = a_data[a_row + p];
-            let b_row = p * n;
-            for j in 0..n {
-                result[res_row + j] += a_val * b_data[b_row + j];
+    // Tile size for L1 cache locality
+    const TILE: usize = 32;
+
+    // Tiled ikj loop: outer loops iterate tiles, inner loops within tiles.
+    let mut ii = 0;
+    while ii < m {
+        let i_end = (ii + TILE).min(m);
+        let mut pp = 0;
+        while pp < k {
+            let p_end = (pp + TILE).min(k);
+            let mut jj = 0;
+            while jj < n {
+                let j_end = (jj + TILE).min(n);
+                // Inner tile: ikj order for cache-friendly access
+                for i in ii..i_end {
+                    let a_row = i * k;
+                    let r_row = i * n;
+                    for p in pp..p_end {
+                        let a_val = a_data[a_row + p];
+                        let b_row = p * n;
+                        for j in jj..j_end {
+                            result[r_row + j] += a_val * b_data[b_row + j];
+                        }
+                    }
+                }
+                jj += TILE;
             }
+            pp += TILE;
         }
+        ii += TILE;
     }
 
     Tensor::from_data(result, vec![m, n])
@@ -401,14 +422,20 @@ pub fn bmm(a: &Tensor, b: &Tensor) -> Tensor {
     let b_data = b.contiguous().to_vec();
     let mut result = vec![0.0f32; batch * m * n];
 
+    // Use cache-friendly ikj loop order for each batch element
     for bi in 0..batch {
+        let a_offset = bi * m * k;
+        let b_offset = bi * k * n;
+        let r_offset = bi * m * n;
         for i in 0..m {
-            for j in 0..n {
-                let mut s = 0.0f32;
-                for p in 0..k {
-                    s += a_data[bi * m * k + i * k + p] * b_data[bi * k * n + p * n + j];
+            let a_row = a_offset + i * k;
+            let r_row = r_offset + i * n;
+            for p in 0..k {
+                let a_val = a_data[a_row + p];
+                let b_row = b_offset + p * n;
+                for j in 0..n {
+                    result[r_row + j] += a_val * b_data[b_row + j];
                 }
-                result[bi * m * n + i * n + j] = s;
             }
         }
     }


### PR DESCRIPTION
## Summary
- **Tiled matmul**: Adds 32x32 cache-blocking to the existing ikj loop order matmul. Three tiles of 32x32 f32 = 12KB fits in L1 cache, improving temporal locality for larger matrices (784x128, 256x256).
- **BMM optimization**: Applies ikj loop order to batched matmul for cache-friendly access.
- **Autograd benchmarks**: New `benchmarks/bench_autograd.py` with timing for forward/backward passes through Linear layers, MLP architectures, loss functions, reductions, and no_grad overhead.

All 29 Rust tests + 185 Python tests pass.
Build time: cargo test 0.36s, maturin develop --release 7.7s

Closes #7 (partial)

## Test plan
- [x] `cargo test` passes (29 tests)
- [x] `python -m pytest tests/ -v` passes (185 tests)
- [x] Matmul results unchanged (verified via existing test_matmul tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)